### PR TITLE
Add Docker support and helper scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gitignore
+.dockerignore
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.venv
+*.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.13-slim
+
+ENV UV_PROJECT_ENVIRONMENT=/app/.venv
+
+# Install uv
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+
+# Copy project metadata
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies without installing the project itself
+RUN uv sync --frozen --no-install-project
+
+# Copy application code
+COPY choretracker ./choretracker
+
+EXPOSE 8000
+
+CMD ["uv", "run", "uvicorn", "choretracker.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: docker-start docker-stop docker-rebuild
+
+docker-start:
+	docker compose up --no-build -d
+
+docker-stop:
+	docker compose down
+
+docker-rebuild:
+	docker compose build web
+	docker compose up -d

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # choretracker
+
+## Docker
+
+The app can run inside Docker containers.
+
+### Quick start
+
+- **Start the webserver** (uses existing image):
+  ```bash
+  make docker-start
+  ```
+- **Stop the containers**:
+  ```bash
+  make docker-stop
+  ```
+- **Rebuild the webserver image and restart**:
+  ```bash
+  make docker-rebuild
+  ```
+
+The webserver listens on [http://localhost:8000](http://localhost:8000).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  web:
+    image: benpelletier/choretracker_webserver
+    build: .
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
## Summary
- containerize the FastAPI webserver with a `Dockerfile` using uv
- define docker-compose service with image `benpelletier/choretracker_webserver`
- add Makefile helpers for starting, stopping, and rebuilding the webserver
- document docker workflow in README

## Testing
- `uv run python -m py_compile choretracker/app.py`
- `docker-compose config`
- `docker-compose build web` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_68a8eb8ac574832c9bb0ac289c59ff06