### PR TITLE
feat: add template-based index page with static styling

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -1,8 +1,17 @@
-from fastapi import FastAPI
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 
 app = FastAPI()
 
+BASE_PATH = Path(__file__).resolve().parent
+templates = Jinja2Templates(directory=str(BASE_PATH / "templates"))
+app.mount("/static", StaticFiles(directory=str(BASE_PATH / "static")), name="static")
 
-@app.get("/")
-async def read_root():
-    return {"message": "Hello, World!"}
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})

--- a/choretracker/static/home.svg
+++ b/choretracker/static/home.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
+</svg>

--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -1,0 +1,34 @@
+body {
+    margin: 0;
+    font-family: system-ui, sans-serif;
+    background-color: #f9fafb;
+    color: #111827;
+}
+
+.navbar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    background-color: #ffffff;
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    z-index: 1000;
+}
+
+.navbar .nav-item {
+    display: flex;
+    align-items: center;
+}
+
+.navbar .icon {
+    width: 1.5rem;
+    height: 1.5rem;
+}
+
+.content {
+    padding: 1rem;
+    margin-top: 3rem; /* prevent content from hiding under navbar */
+}

--- a/choretracker/templates/base.html
+++ b/choretracker/templates/base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}Chore Tracker{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', path='styles.css') }}">
+</head>
+<body>
+    <nav class="navbar">
+        <a href="{{ url_for('index') }}" class="nav-item">
+            <img src="{{ url_for('static', path='home.svg') }}" alt="Home" class="icon">
+        </a>
+    </nav>
+    <main class="content">
+        {% block content %}{% endblock %}
+    </main>
+</body>
+</html>

--- a/choretracker/templates/index.html
+++ b/choretracker/templates/index.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block title %}Home - Chore Tracker{% endblock %}
+
+{% block content %}
+<h1>Welcome to Chore Tracker</h1>
+<p>Manage your household chores with ease.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- serve a template-driven index page
- add reusable base layout with sticky navbar and home icon
- include kiosk-friendly CSS and static assets

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8f1cb47fc832cab11dfa8617429f1