### PR TITLE
Add basic user management with in-memory store

### DIFF
--- a/choretracker/templates/base.html
+++ b/choretracker/templates/base.html
@@ -16,9 +16,12 @@
         <div class="user-menu">
             <button class="user-button">{{ current_user }}</button>
             <div class="dropdown">
-                {% for u in ALL_USERS if u != current_user %}
+                {% for u in all_users() if u != current_user %}
                 <a href="{{ url_for('switch_user', username=u) }}">{{ u }}</a>
                 {% endfor %}
+                {% if user_has(current_user, 'iam') %}
+                <a href="{{ url_for('list_users') }}">Manage users</a>
+                {% endif %}
                 <a href="{{ url_for('logout') }}">Sign out</a>
             </div>
         </div>

--- a/choretracker/templates/users/form.html
+++ b/choretracker/templates/users/form.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% if user %}
+    {% set page_title = 'Edit user' %}
+{% else %}
+    {% set page_title = 'New user' %}
+{% endif %}
+
+{% block title %}{{ page_title }} - Chore Tracker{% endblock %}
+
+{% block content %}
+<h1>{{ page_title }}</h1>
+<form method="post">
+    <label>Username: <input type="text" name="username" value="{{ user.username if user else '' }}"></label><br>
+    <label>Password: <input type="text" name="password" value="{{ user.password if user and user.password else '' }}"></label><br>
+    <label><input type="checkbox" name="iam" {% if user and 'iam' in user.permissions %}checked{% endif %}> Can manage users</label><br>
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/choretracker/templates/users/list.html
+++ b/choretracker/templates/users/list.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block title %}Users - Chore Tracker{% endblock %}
+
+{% block content %}
+<h1>Users</h1>
+<p><a href="{{ url_for('new_user') }}">New user</a></p>
+<ul>
+{% for u in users %}
+    <li>
+        {{ u.username }}{% if 'iam' in u.permissions %} (iam){% endif %}
+        <a href="{{ url_for('edit_user', username=u.username) }}">Edit</a>
+        <form method="post" action="{{ url_for('delete_user', username=u.username) }}" style="display:inline">
+            <button type="submit">Delete</button>
+        </form>
+    </li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/choretracker/users.py
+++ b/choretracker/users.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+
+
+@dataclass
+class User:
+    username: str
+    password: Optional[str] = None
+    permissions: Set[str] = field(default_factory=set)
+
+
+class UserStore:
+    def __init__(self, initial_users: Optional[List[User]] = None):
+        self.users: Dict[str, User] = {u.username: u for u in initial_users or []}
+
+    def list_users(self) -> List[User]:
+        return list(self.users.values())
+
+    def get(self, username: str) -> Optional[User]:
+        return self.users.get(username)
+
+    def create(self, user: User) -> None:
+        self.users[user.username] = user
+
+    def update(self, old_username: str, user: User) -> None:
+        if old_username != user.username:
+            self.users.pop(old_username, None)
+        self.users[user.username] = user
+
+    def delete(self, username: str) -> None:
+        self.users.pop(username, None)
+
+    def has_permission(self, username: str, permission: str) -> bool:
+        user = self.get(username)
+        return permission in user.permissions if user else False


### PR DESCRIPTION
## Summary
- introduce `User` model and `UserStore` for in-memory user management
- add CRUD endpoints and templates to manage users
- show **Manage users** link in nav for users with `iam` permission

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a912db9d84832cae293cbfa6891c10