### PR TITLE
Add calendar entry deletion with confirmation

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -456,6 +456,19 @@ async def update_calendar_entry(request: Request, entry_id: int):
     )
 
 
+@app.post("/calendar/{entry_id}/delete")
+async def delete_calendar_entry(request: Request, entry_id: int):
+    entry = calendar_store.get(entry_id)
+    if not entry:
+        raise HTTPException(status_code=404)
+    require_entry_write_permission(request, entry)
+    calendar_store.delete(entry_id)
+    return RedirectResponse(
+        url=request.url_for("list_calendar_entries", entry_type=entry.type.value),
+        status_code=303,
+    )
+
+
 @app.get("/users", response_class=HTMLResponse)
 async def list_users(request: Request):
     require_permission(request, "iam")

--- a/choretracker/calendar.py
+++ b/choretracker/calendar.py
@@ -101,6 +101,13 @@ class CalendarEntryStore:
                 ]
             return entries
 
+    def delete(self, entry_id: int) -> None:
+        with Session(self.engine) as session:
+            entry = session.get(CalendarEntry, entry_id)
+            if entry:
+                session.delete(entry)
+                session.commit()
+
 
 @dataclass
 class TimePeriod:

--- a/choretracker/templates/calendar/list.html
+++ b/choretracker/templates/calendar/list.html
@@ -12,6 +12,9 @@
         {% set edit_perm = EDIT_OTHER_PERMS[entry_type] %}
         {% if user_has(current_user, write_perm) and (entry.owner == current_user or user_has(current_user, edit_perm)) %}
         <a href="{{ url_for('edit_calendar_entry', entry_id=entry.id) }}" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></a>
+        <form method="post" action="{{ url_for('delete_calendar_entry', entry_id=entry.id) }}" style="display:inline" onsubmit="return confirm('Are you sure you want to delete this entry?');">
+            <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
+        </form>
         {% endif %}
     </li>
     {% else %}

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -6,6 +6,9 @@
 <h1>{{ entry.title }}
     {% if can_edit %}
     <a href="{{ url_for('edit_calendar_entry', entry_id=entry.id) }}" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></a>
+    <form method="post" action="{{ url_for('delete_calendar_entry', entry_id=entry.id) }}" style="display:inline" onsubmit="return confirm('Are you sure you want to delete this entry?');">
+        <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
+    </form>
     {% endif %}
 </h1>
 <p>{{ entry.description }}</p>


### PR DESCRIPTION
## Summary
- allow calendar entries to be deleted from the database
- add delete endpoint with permission checks for calendar entries
- show delete icon with confirmation on calendar entry lists and detail pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab7b269278832c813c15a802a0ddc6