### PR TITLE
Add chore completion tracking and permissions

### DIFF
--- a/choretracker/static/checkbox-checked.svg
+++ b/choretracker/static/checkbox-checked.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#111827" stroke-width="2">
+  <rect x="2" y="2" width="20" height="20" rx="2" ry="2" />
+  <polyline points="6 12 10 16 18 8" />
+</svg>

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -39,4 +39,32 @@
     <dt>Responsible</dt><dd>{{ entry.responsible|join(', ') }}</dd>
     <dt>Owner</dt><dd>{{ entry.owner }}</dd>
 </dl>
+{% if completions %}
+<h2>Completions</h2>
+<ul class="time-list">
+    {% for comp, period, can_remove in completions %}
+    <li>
+        {{ comp.completed_by }} {{ comp.completed_at }} due {{ period.end }}
+        {% if can_remove %}
+        <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ comp.recurrence_index }}" data-iindex="{{ comp.instance_index }}" data-action="remove" />
+        {% endif %}
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+<script>
+document.querySelectorAll('.checkbox-icon[data-action="remove"]').forEach(el => {
+    el.addEventListener('click', async () => {
+        const entry = el.dataset.entry;
+        const r = parseInt(el.dataset.rindex);
+        const i = parseInt(el.dataset.iindex);
+        await fetch(`/calendar/${entry}/completion/remove`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({recurrence_index: r, instance_index: i})
+        });
+        location.reload();
+    });
+});
+</script>
 {% endblock %}

--- a/choretracker/templates/index.html
+++ b/choretracker/templates/index.html
@@ -13,7 +13,9 @@
         {% endfor %}
         {{ entry.title }}
         <span class="time-suffix" data-kind="due-ago" data-end="{{ period.end.isoformat() }}"></span>
-        <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" />
+        {% if user_has(request.session.get('user'), 'chores.complete_overdue') %}
+        <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" data-action="add" />
+        {% endif %}
     </li>
     {% endfor %}
 </ul>
@@ -22,7 +24,7 @@
 {% if now_periods %}
 <h2>Now</h2>
 <ul class="time-list">
-    {% for entry, period in now_periods %}
+    {% for entry, period, completion in now_periods %}
     <li>
         {% for user in entry.responsible %}
         <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
@@ -30,7 +32,11 @@
         {{ entry.title }}
         {% if entry.type == CalendarEntryType.Chore %}
         <span class="time-suffix" data-kind="due-in" data-end="{{ period.end.isoformat() }}"></span>
-        <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" />
+        {% if completion %}
+        <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" {% if completion.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
+        {% elif user_has(request.session.get('user'), 'chores.complete_on_time') %}
+        <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" data-action="add" />
+        {% endif %}
         {% endif %}
     </li>
     {% endfor %}
@@ -92,6 +98,23 @@ function updateTimes() {
 }
 updateTimes();
 setInterval(updateTimes, 1000);
+
+document.querySelectorAll('.checkbox-icon[data-action]').forEach(el => {
+    el.addEventListener('click', async () => {
+        const entry = el.dataset.entry;
+        const r = parseInt(el.dataset.rindex);
+        const i = parseInt(el.dataset.iindex);
+        const url = el.dataset.action === 'add'
+            ? `/calendar/${entry}/completion`
+            : `/calendar/${entry}/completion/remove`;
+        await fetch(url, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({recurrence_index: r, instance_index: i})
+        });
+        location.reload();
+    });
+});
 </script>
 {% endblock %}
 

--- a/choretracker/templates/users/form.html
+++ b/choretracker/templates/users/form.html
@@ -87,6 +87,18 @@
                 <input type="checkbox" name="chores.edit_others" {% if user and 'chores.edit_others' in user.permissions %}checked{% endif %}>
                 <span>Edit others'</span>
             </label>
+            <label class="checkbox">
+                <input type="checkbox" name="chores.complete_on_time" {% if user and 'chores.complete_on_time' in user.permissions %}checked{% endif %}>
+                <span>Complete on time</span>
+            </label>
+            <label class="checkbox">
+                <input type="checkbox" name="chores.complete_overdue" {% if user and 'chores.complete_overdue' in user.permissions %}checked{% endif %}>
+                <span>Complete overdue</span>
+            </label>
+            <label class="checkbox">
+                <input type="checkbox" name="chores.override_complete" {% if user and 'chores.override_complete' in user.permissions %}checked{% endif %}>
+                <span>Remove any completion</span>
+            </label>
         </div>
         <div class="group">
             <h3>Events</h3>


### PR DESCRIPTION
## Summary
- add `ChoreCompletion` model and store to track chore completions
- introduce permissions for completing chores and overriding completions
- allow toggling chore completion from main and detail pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab8906a4a4832c955012e3a9afa247