### PR TITLE
Refine spacing and add auto logout refresh

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -91,6 +91,7 @@ templates.env.globals["user_has"] = user_store.has_permission
 templates.env.globals["WRITE_PERMS"] = WRITE_PERMS
 templates.env.globals["EDIT_OTHER_PERMS"] = EDIT_OTHER_PERMS
 templates.env.globals["timedelta"] = timedelta
+templates.env.globals["LOGOUT_DURATION"] = LOGOUT_DURATION
 app.mount("/static", StaticFiles(directory=str(BASE_PATH / "static")), name="static")
 
 
@@ -284,6 +285,8 @@ async def profile_picture(username: str):
     user = user_store.get(username)
     if user and user.profile_picture:
         return Response(user.profile_picture, media_type="image/png")
+    if username == "Viewer":
+        return FileResponse(BASE_PATH / "static" / "viewer_profile.png")
     return FileResponse(BASE_PATH / "static" / "default_profile.png")
 
 

--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -17,6 +17,10 @@ h1 {
     margin-top: 0;
 }
 
+h1, h2, h3, h4, h5, h6 {
+    margin-bottom: 0.25rem;
+}
+
 .navbar {
     position: fixed;
     top: 0;
@@ -49,7 +53,7 @@ h1 {
 }
 
 .content {
-    padding: 0.5rem;
+    padding: 0.25rem;
     margin-top: 2.5rem; /* prevent content from hiding under navbar */
 }
 
@@ -101,7 +105,7 @@ h1 {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    padding: 0.5rem;
+    padding: 0.25rem;
 }
 
 /* Form field layout */
@@ -316,6 +320,10 @@ h1 {
     margin-right: 0.25rem;
 }
 
+.time-list .profile-icon + .profile-icon {
+    margin-left: -0.25rem;
+}
+
 .checkbox-icon {
     height: 1em;
     width: 1em;
@@ -375,4 +383,8 @@ h1 {
 .pin-error {
     color: #b91c1c;
     margin-top: 0.5rem;
+}
+
+h1 .icon-button {
+    margin-left: 0.25rem;
 }

--- a/choretracker/templates/base.html
+++ b/choretracker/templates/base.html
@@ -225,6 +225,13 @@
                 }
             });
         }
+
+        var loggedInUser = "{{ request.session.get('user') }}";
+        if (loggedInUser && loggedInUser !== 'Viewer') {
+            setTimeout(function () {
+                window.location.reload();
+            }, ({{ LOGOUT_DURATION.total_seconds()|int }} + 1) * 1000);
+        }
     });
     </script>
 </body>

--- a/choretracker/templates/calendar/list.html
+++ b/choretracker/templates/calendar/list.html
@@ -3,7 +3,7 @@
 {% block title %}{{ entry_type.value }}s - Chore Tracker{% endblock %}
 
 {% block content %}
-<h1>{{ entry_type.value }}s</h1>
+<h1>{{ entry_type.value }}s{% if user_has(current_user, WRITE_PERMS[entry_type]) %}<a href="{{ url_for('new_calendar_entry', entry_type=entry_type.value) }}" class="icon-button"><img src="{{ url_for('static', path='plus.svg') }}" alt="Add" class="icon"></a>{% endif %}</h1>
 <ul>
     {% for entry in entries %}
     <li>


### PR DESCRIPTION
## Summary
- tighten margins around content and headings for a more compact layout
- refresh or redirect after logout timeout and use dedicated viewer avatar
- allow quick creation of calendar entries via new '+' header button

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab927d1e44832c8d3161c60a069b42