### PR TITLE
Disambiguate calendar entries with duplicate names

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -93,6 +93,14 @@ templates.env.globals["WRITE_PERMS"] = WRITE_PERMS
 templates.env.globals["EDIT_OTHER_PERMS"] = EDIT_OTHER_PERMS
 templates.env.globals["timedelta"] = timedelta
 templates.env.globals["LOGOUT_DURATION"] = LOGOUT_DURATION
+def format_datetime(dt: datetime | None, include_day: bool = False) -> str:
+    if not dt:
+        return ""
+    fmt = "%Y-%m-%d %H:%M"
+    if include_day:
+        fmt = "%A " + fmt
+    return dt.strftime(fmt)
+templates.env.filters["format_datetime"] = format_datetime
 app.mount("/static", StaticFiles(directory=str(BASE_PATH / "static")), name="static")
 
 
@@ -392,7 +400,7 @@ async def list_calendar_entries(request: Request, entry_type: str):
     counts = Counter(e.title for e in entries)
     for entry in entries:
         if counts[entry.title] > 1:
-            entry.title = f"{entry.title} ({entry.first_start.strftime('%Y-%m-%d %H:%M:%S')})"
+            entry.title = f"{entry.title} ({format_datetime(entry.first_start, include_day=True)})"
     current_user = request.session.get("user")
     return templates.TemplateResponse(
         "calendar/list.html",

--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from heapq import heappush, heappop
 from typing import Iterator
 from itertools import count
+from collections import Counter
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response, FileResponse, JSONResponse
@@ -388,6 +389,10 @@ async def list_calendar_entries(request: Request, entry_type: str):
         raise HTTPException(status_code=404)
     require_entry_read_permission(request, etype)
     entries = [e for e in calendar_store.list_entries() if e.type == etype]
+    counts = Counter(e.title for e in entries)
+    for entry in entries:
+        if counts[entry.title] > 1:
+            entry.title = f"{entry.title} ({entry.first_start.strftime('%Y-%m-%d %H:%M:%S')})"
     current_user = request.session.get("user")
     return templates.TemplateResponse(
         "calendar/list.html",

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -14,7 +14,7 @@
 <p>{{ entry.description }}</p>
 <dl>
     <dt>Type</dt><dd>{{ entry.type.value }}</dd>
-    <dt>First start</dt><dd>{{ entry.first_start }}</dd>
+    <dt>First start</dt><dd>{{ entry.first_start|format_datetime }}</dd>
     <dt>Duration</dt><dd>{{ entry.duration }}</dd>
     <dt>Recurrences</dt>
     <dd>
@@ -35,7 +35,7 @@
         None
         {% endif %}
     </dd>
-    <dt>None after</dt><dd>{{ entry.none_after }}</dd>
+    <dt>None after</dt><dd>{{ entry.none_after|format_datetime }}</dd>
     <dt>Responsible</dt><dd>{{ entry.responsible|join(', ') }}</dd>
     <dt>Owner</dt><dd>{{ entry.owner }}</dd>
 </dl>
@@ -44,7 +44,7 @@
 <ul class="time-list">
     {% for comp, period, can_remove in completions %}
     <li>
-        {{ comp.completed_by }} {{ comp.completed_at }} due {{ period.end }}
+        {{ comp.completed_by }} {{ comp.completed_at|format_datetime }} due {{ period.end|format_datetime }}
         {% if can_remove %}
         <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ comp.recurrence_index }}" data-iindex="{{ comp.instance_index }}" data-action="remove" />
         {% endif %}

--- a/tests/test_calendar_list_disambiguation.py
+++ b/tests/test_calendar_list_disambiguation.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+# Ensure project root is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import CalendarEntry, CalendarEntryType
+
+
+def test_duplicate_titles_disambiguated(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    app_module = importlib.import_module("choretracker.app")
+    client = TestClient(app_module.app)
+
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    first = CalendarEntry(
+        title="Guinea salad",
+        description="",
+        type=CalendarEntryType.Event,
+        first_start=datetime(2025, 8, 22, 8, 0, 0),
+        duration_seconds=60,
+    )
+    second = CalendarEntry(
+        title="Guinea salad",
+        description="",
+        type=CalendarEntryType.Event,
+        first_start=datetime(2025, 8, 23, 8, 0, 0),
+        duration_seconds=60,
+    )
+    app_module.calendar_store.create(first)
+    app_module.calendar_store.create(second)
+
+    response = client.get("/calendar/list/Event")
+    assert "Guinea salad (2025-08-22 08:00:00)" in response.text
+    assert "Guinea salad (2025-08-23 08:00:00)" in response.text

--- a/tests/test_calendar_list_disambiguation.py
+++ b/tests/test_calendar_list_disambiguation.py
@@ -37,5 +37,5 @@ def test_duplicate_titles_disambiguated(tmp_path, monkeypatch):
     app_module.calendar_store.create(second)
 
     response = client.get("/calendar/list/Event")
-    assert "Guinea salad (2025-08-22 08:00:00)" in response.text
-    assert "Guinea salad (2025-08-23 08:00:00)" in response.text
+    assert "Guinea salad (Friday 2025-08-22 08:00)" in response.text
+    assert "Guinea salad (Saturday 2025-08-23 08:00)" in response.text


### PR DESCRIPTION
## Summary
- Show first start time beside calendar entries when multiple entries share a title
- Add regression test for duplicate title disambiguation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab98120e34832cbcfc80b8c93b919c