### PR TITLE
Add TimePeriod detail page with skip controls

### DIFF
--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -331,6 +331,12 @@ h1 {
     margin-left: 0.25rem;
 }
 
+/* Make skip/unskip buttons match surrounding text size */
+.skip-button {
+    font-size: 1rem;
+    padding: 0.25rem 0.5rem;
+}
+
 .pin-modal {
     position: fixed;
     top: 0;

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -20,6 +20,9 @@
             <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" data-action="add" />
             {% endif %}
         {% endif %}
+        {% if completion %}
+        <span class="completed-by">by {{ completion.completed_by }}</span>
+        {% endif %}
     {% endif %}
 </div>
 <p>{{ entry.description }}</p>

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -30,7 +30,7 @@
 <form method="post" action="{{ request.url_for(is_skipped and 'unskip_instance' or 'skip_instance', entry_id=entry.id) }}">
     <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
     <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
-    <button type="submit">{{ 'Do not skip this instance' if is_skipped else 'Skip this instance' }}</button>
+    <button type="submit" class="skip-button">{{ 'Do not skip this instance' if is_skipped else 'Skip this instance' }}</button>
 </form>
 {% endif %}
 <script>

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+
+{% block title %}{{ entry.title }} - Chore Tracker{% endblock %}
+
+{% block content %}
+<h1><a href="{{ request.url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a></h1>
+<div class="time-range">
+    <span>{{ period|format_time_range }}</span>
+    {% if entry.type == CalendarEntryType.Chore %}
+        {% if period.end <= now %}
+            {% if not completion and user_has(request.session.get('user'), 'chores.complete_overdue') %}
+            <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" data-action="add" />
+            {% elif completion %}
+            <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" {% if completion.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
+            {% endif %}
+        {% elif period.start <= now %}
+            {% if completion %}
+            <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" {% if completion.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
+            {% elif user_has(request.session.get('user'), 'chores.complete_on_time') %}
+            <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" data-action="add" />
+            {% endif %}
+        {% endif %}
+    {% endif %}
+</div>
+<p>{{ entry.description }}</p>
+{% if can_edit and period.recurrence_index >= 0 %}
+<form method="post" action="{{ request.url_for(is_skipped and 'unskip_instance' or 'skip_instance', entry_id=entry.id) }}">
+    <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
+    <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+    <button type="submit">{{ 'Do not skip this instance' if is_skipped else 'Skip this instance' }}</button>
+</form>
+{% endif %}
+<script>
+document.querySelectorAll('.checkbox-icon[data-action]').forEach(el => {
+    el.addEventListener('click', async () => {
+        const entry = el.dataset.entry;
+        const r = parseInt(el.dataset.rindex);
+        const i = parseInt(el.dataset.iindex);
+        const url = el.dataset.action === 'add' ? `/calendar/${entry}/completion` : `/calendar/${entry}/completion/remove`;
+        await fetch(url, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({recurrence_index: r, instance_index: i})
+        });
+        location.reload();
+    });
+});
+</script>
+{% endblock %}

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -44,7 +44,8 @@
 <ul class="time-list">
     {% for comp, period, can_remove in completions %}
     <li>
-        {{ comp.completed_by }} {{ comp.completed_at|format_datetime }} due {{ period.end|format_datetime }}
+        {{ comp.completed_by }} {{ comp.completed_at|format_datetime }}
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=comp.recurrence_index, iindex=comp.instance_index) }}">due {{ period.end|format_datetime }}</a>
         {% if can_remove %}
         <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ comp.recurrence_index }}" data-iindex="{{ comp.instance_index }}" data-action="remove" />
         {% endif %}

--- a/choretracker/templates/index.html
+++ b/choretracker/templates/index.html
@@ -11,7 +11,7 @@
         {% for user in entry.responsible %}
         <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        {{ entry.title }}
+        <a href="{{ request.url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>
         <span class="time-suffix" data-kind="due-ago" data-end="{{ period.end.isoformat() }}"></span>
         {% if user_has(request.session.get('user'), 'chores.complete_overdue') %}
         <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" data-action="add" />
@@ -29,7 +29,7 @@
         {% for user in entry.responsible %}
         <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        {{ entry.title }}
+        <a href="{{ request.url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>
         {% if entry.type == CalendarEntryType.Chore %}
         <span class="time-suffix" data-kind="due-in" data-end="{{ period.end.isoformat() }}"></span>
         {% if completion %}
@@ -51,7 +51,7 @@
         {% for user in entry.responsible %}
         <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        {{ entry.title }}
+        <a href="{{ request.url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>
         <span class="time-suffix" data-kind="starts-in" data-start="{{ period.start.isoformat() }}"></span>
     </li>
     {% endfor %}

--- a/tests/test_timeperiod_completed_by.py
+++ b/tests/test_timeperiod_completed_by.py
@@ -1,0 +1,45 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+)
+
+
+def test_completed_by_username_shown(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+    client = TestClient(app_module.app)
+
+    # login as Admin user
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    entry = CalendarEntry(
+        title="Dishes",
+        description="",
+        type=CalendarEntryType.Chore,
+        first_start=datetime(2000, 1, 1, 8, 0, 0),
+        duration_seconds=60,
+        recurrences=[Recurrence(type=RecurrenceType.Weekly)],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    # mark completion for first recurrence instance
+    app_module.completion_store.create(entry_id, 0, 0, "Admin")
+
+    response = client.get(f"/calendar/entry/{entry_id}/period/0/0")
+    assert '<span class="completed-by">by Admin</span>' in response.text


### PR DESCRIPTION
## Summary
- link calendar items on home page to new TimePeriod view
- show time range, completion checkbox, and skip/unskip button for a specific instance
- support including skipped instances when finding time periods

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab9eb2f27c832c92c1305298e278d1