### PR TITLE
Clarify calendar entry and instance headings

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -106,6 +106,42 @@ def format_datetime(dt: datetime | None, include_day: bool = False) -> str:
 templates.env.filters["format_datetime"] = format_datetime
 
 
+def format_duration(td: timedelta | None) -> str:
+    if not td:
+        return ""
+    td = td - timedelta(seconds=td.seconds % 60, microseconds=td.microseconds)
+    s = str(td)
+    if s.endswith(":00"):
+        s = s[:-3]
+    return s
+
+
+def format_offset(offset: Offset | None) -> str:
+    if not offset:
+        return ""
+    parts: list[str] = []
+    if offset.years:
+        parts.append(f"{offset.years}Y")
+    if offset.months:
+        parts.append(f"{offset.months}M")
+    if offset.exact_duration_seconds:
+        td = timedelta(seconds=offset.exact_duration_seconds)
+        days = td.days
+        hours, remainder = divmod(td.seconds, 3600)
+        minutes = remainder // 60
+        if days:
+            parts.append(f"{days}d")
+        if hours:
+            parts.append(f"{hours}h")
+        if minutes:
+            parts.append(f"{minutes}m")
+    return "".join(parts)
+
+
+templates.env.filters["format_duration"] = format_duration
+templates.env.filters["format_offset"] = format_offset
+
+
 def format_time_range(period: TimePeriod) -> str:
     start = period.start.replace(second=0, microsecond=0)
     end = period.end.replace(second=0, microsecond=0)

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 
-{% block title %}{{ entry.title }} - Chore Tracker{% endblock %}
+{% block title %}{{ entry.title }} instance - Chore Tracker{% endblock %}
 
 {% block content %}
-<h1><a href="{{ request.url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a></h1>
+<h1><a href="{{ request.url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a> instance</h1>
 <div class="time-range">
     <span>{{ period|format_time_range }}</span>
     {% for user in responsible %}

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 
-{% block title %}{{ entry.title }} - Chore Tracker{% endblock %}
+{% block title %}{{ entry.title }} {{ entry.type.value }} - Chore Tracker{% endblock %}
 
 {% block content %}
-<h1>{{ entry.title }}
+<h1>{{ entry.title }} {{ entry.type.value }}
     {% if can_edit %}
     <a href="{{ url_for('edit_calendar_entry', entry_id=entry.id) }}" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></a>
     <form method="post" action="{{ url_for('delete_calendar_entry', entry_id=entry.id) }}" style="display:inline" onsubmit="return confirm('Are you sure you want to delete this entry?');">
@@ -13,29 +13,27 @@
 </h1>
 <p>{{ entry.description }}</p>
 <dl>
-    <dt>Type</dt><dd>{{ entry.type.value }}</dd>
-    <dt>First start</dt><dd>{{ entry.first_start|format_datetime }}</dd>
-    <dt>Duration</dt><dd>{{ entry.duration }}</dd>
+    <dt>First start: {{ entry.first_start|format_datetime(include_day=True) }}</dt>
+    <dt>Duration: {{ entry.duration|format_duration }}</dt>
     <dt>Recurrences</dt>
     <dd>
         {% if entry.recurrences %}
         <ul>
             {% for rec in entry.recurrences %}
-            <li>{{ rec.type.value }}{% if rec.offset %} (offset:
-                {% if rec.offset.exact_duration_seconds %}
-                    {{ timedelta(seconds=rec.offset.exact_duration_seconds) }}
-                {% endif %}
-                {% if rec.offset.months %} {{ rec.offset.months }} months{% endif %}
-                {% if rec.offset.years %} {{ rec.offset.years }} years{% endif %}
-                ){% endif %}
-            </li>
+            <li>{{ rec.type.value }}{% if rec.offset %} (offset: {{ rec.offset|format_offset }}){% endif %}</li>
             {% endfor %}
         </ul>
         {% else %}
         None
         {% endif %}
     </dd>
-    <dt>None after</dt><dd>{{ entry.none_after|format_datetime }}</dd>
+    {% if entry.recurrences %}
+        {% if entry.none_after %}
+    <dt>None after: {{ entry.none_after|format_datetime(include_day=True) }}</dt>
+        {% else %}
+    <dt>Repeats forever</dt>
+        {% endif %}
+    {% endif %}
     <dt>Responsible</dt><dd>{{ entry.responsible|join(', ') }}</dd>
     <dt>Owner</dt><dd>{{ entry.owner }}</dd>
 </dl>


### PR DESCRIPTION
## Summary
- Show calendar entry type in page title and heading and drop type field
- Display first start and duration inline with cleaner formatting
- Label time period pages as distinct instances

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abc5524124832c9583f61e0667ab4e