### PR TITLE
Render CalendarEntry descriptions as Markdown

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -16,6 +16,8 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 from sqlmodel import create_engine
 from pydantic.json import pydantic_encoder
+from markdown import markdown as md
+from markupsafe import Markup
 
 from .users import UserStore, init_db, process_profile_picture, pwd_context
 from .calendar import (
@@ -140,6 +142,15 @@ def format_offset(offset: Offset | None) -> str:
 
 templates.env.filters["format_duration"] = format_duration
 templates.env.filters["format_offset"] = format_offset
+
+
+def render_markdown(text: str) -> Markup:
+    if not text:
+        return Markup("")
+    return Markup(md(text))
+
+
+templates.env.filters["markdown"] = render_markdown
 
 
 def format_time_range(period: TimePeriod) -> str:

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -28,7 +28,7 @@
         {% endif %}
     {% endif %}
 </div>
-<p>{{ entry.description }}</p>
+<div class="description">{{ entry.description|markdown }}</div>
 {% if can_edit and period.recurrence_index >= 0 %}
 <form method="post" action="{{ request.url_for(is_skipped and 'unskip_instance' or 'skip_instance', entry_id=entry.id) }}">
     <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -11,7 +11,7 @@
     </form>
     {% endif %}
 </h1>
-<p>{{ entry.description }}</p>
+<div class="description">{{ entry.description|markdown }}</div>
 <dl>
     <dt>First start: {{ entry.first_start|format_datetime(include_day=True) }}</dt>
     <dt>Duration: {{ entry.duration|format_duration }}</dt>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "alembic>=1.16.4",
     "itsdangerous>=2.2.0",
     "apscheduler>=3.11.0",
+    "markdown>=3.5",
     "python-multipart>=0.0.20",
     "passlib[bcrypt]>=1.7.4",
     "bcrypt>=4.1",

--- a/tests/test_description_markdown.py
+++ b/tests/test_description_markdown.py
@@ -1,0 +1,34 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+# Ensure project root is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import CalendarEntry, CalendarEntryType
+
+
+def test_description_rendered_as_markdown(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    app_module = importlib.import_module("choretracker.app")
+    client = TestClient(app_module.app)
+
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    entry = CalendarEntry(
+        title="Markdown",
+        description="**bold**",
+        type=CalendarEntryType.Event,
+        first_start=datetime(2025, 1, 1, 0, 0, 0),
+        duration_seconds=60,
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[-1].id
+
+    response = client.get(f"/calendar/entry/{entry_id}")
+    assert "<strong>bold</strong>" in response.text
+    assert "**bold**" not in response.text

--- a/uv.lock
+++ b/uv.lock
@@ -111,6 +111,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "itsdangerous" },
     { name = "jinja2" },
+    { name = "markdown" },
     { name = "passlib", extra = ["bcrypt"] },
     { name = "pillow" },
     { name = "python-multipart" },
@@ -126,6 +127,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "markdown", specifier = ">=3.5" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
@@ -256,6 +258,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/c2/4ab49206c17f75cb08d6311171f2d65798988db4360c4d1485bd0eedd67c/markdown-3.8.2.tar.gz", hash = "sha256:247b9a70dd12e27f67431ce62523e675b866d254f900c4fe75ce3dda62237c45", size = 362071, upload-time = "2025-06-19T17:12:44.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/2b/34cc11786bc00d0f04d0f5fdc3a2b1ae0b6239eef72d3d345805f9ad92a1/markdown-3.8.2-py3-none-any.whl", hash = "sha256:5c83764dbd4e00bdd94d85a19b8d55ccca20fe35b2e678a1422b380324dd5f24", size = 106827, upload-time = "2025-06-19T17:12:42.994Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- render calendar entry descriptions using Markdown
- expose Markdown filter in templates and update views
- cover Markdown rendering with a regression test

## Testing
- `uv run python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abc9b1c520832c8a243896145c8de4