### PR TITLE
Hide due text for completed chores

### DIFF
--- a/choretracker/templates/index.html
+++ b/choretracker/templates/index.html
@@ -31,7 +31,9 @@
         {% endfor %}
         <a href="{{ request.url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>
         {% if entry.type == CalendarEntryType.Chore %}
+        {% if not completion %}
         <span class="time-suffix" data-kind="due-in" data-end="{{ period.end.timestamp() }}"></span>
+        {% endif %}
         {% if completion %}
         <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" {% if completion.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
         {% elif user_has(request.session.get('user'), 'chores.complete_on_time') %}

--- a/tests/test_hide_due_when_completed.py
+++ b/tests/test_hide_due_when_completed.py
@@ -1,0 +1,42 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import CalendarEntry, CalendarEntryType
+import re
+
+
+def test_due_not_shown_when_completed(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+    client = TestClient(app_module.app)
+
+    # login as Admin user
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    now = datetime.now()
+    entry = CalendarEntry(
+        title="Laundry",
+        description="",
+        type=CalendarEntryType.Chore,
+        first_start=now - timedelta(minutes=5),
+        duration_seconds=3600,
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    # mark completion for the period (no recurrence -> indices -1, -1)
+    app_module.completion_store.create(entry_id, -1, -1, "Admin")
+
+    response = client.get("/")
+    assert "Laundry" in response.text
+    assert re.search(r'<span[^>]*data-kind="due-in"', response.text) is None


### PR DESCRIPTION
## Summary
- stop rendering due-in countdown when a chore period already has a completion
- add regression test to ensure completed chores omit due text on the home page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abce328dd8832cb9f16e15cf3868ef