### PR TITLE
Enable inline editing for recurrence responsible users

### DIFF
--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -30,9 +30,17 @@
     <dt>Recurrences</dt>
     <dd>
         {% if entry.recurrences %}
-        <ul>
+        <ul id="recurrence-list">
             {% for rec in entry.recurrences %}
-            <li>{{ rec.type.value }}{% if rec.offset %} (offset: {{ rec.offset|format_offset }}){% endif %}</li>
+            <li class="recurrence-item" data-rindex="{{ loop.index0 }}" data-type="{{ rec.type.value }}" data-offset-seconds="{{ rec.offset.exact_duration_seconds if rec.offset and rec.offset.exact_duration_seconds else 0 }}" data-responsible='{{ rec.responsible|tojson }}'>
+                <span class="recurrence-text">{{ rec.type.value }}{% if rec.offset %} (offset: {{ rec.offset|format_offset }}){% endif %}</span>
+                {% for user in rec.responsible %}
+                <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
+                {% endfor %}
+                {% if can_edit %}
+                <button type="button" class="icon-button edit-recurrence"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
+                {% endif %}
+            </li>
             {% endfor %}
         </ul>
         {% else %}
@@ -105,6 +113,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const entryId = {{ entry.id }};
     const diskUrl = "{{ url_for('static', path='disk.svg') }}";
     const xUrl = "{{ url_for('static', path='x.svg') }}";
+    const trashUrl = "{{ url_for('static', path='trash.svg') }}";
+    const plusUrl = "{{ url_for('static', path='plus.svg') }}";
+    const profileUrlTemplate = "{{ request.url_for('profile_picture', username='__user__') }}";
+    const allUsers = {{ all_users()|selectattr('username','ne','Viewer')|map(attribute='username')|list|tojson }};
 
     function makeBtn(url, alt) {
         const b = document.createElement('button');
@@ -143,6 +155,140 @@ document.addEventListener('DOMContentLoaded', () => {
             cancel.addEventListener('click', () => location.reload());
         });
     }
+
+    document.querySelectorAll('.recurrence-item .edit-recurrence').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const li = btn.closest('.recurrence-item');
+            const rindex = parseInt(li.dataset.rindex);
+            const originalType = li.dataset.type;
+            const originalResp = JSON.parse(li.dataset.responsible || '[]');
+            const offsetSeconds = parseInt(li.dataset.offsetSeconds || '0');
+            const days = Math.floor(offsetSeconds / 86400);
+            const hours = Math.floor((offsetSeconds % 86400) / 3600);
+            const minutes = Math.floor((offsetSeconds % 3600) / 60);
+
+            li.innerHTML = '';
+
+            const typeSelect = document.createElement('select');
+            typeSelect.className = 'inline-input';
+            {% for t in RecurrenceType %}
+            const opt{{ loop.index0 }} = document.createElement('option');
+            opt{{ loop.index0 }}.value = "{{ t.value }}";
+            opt{{ loop.index0 }}.textContent = "{{ t.value }}";
+            if ("{{ t.value }}" === originalType) opt{{ loop.index0 }}.selected = true;
+            typeSelect.appendChild(opt{{ loop.index0 }});
+            {% endfor %}
+
+            const durationSpan = document.createElement('span');
+            const durLabel = document.createElement('span');
+            durLabel.textContent = 'Duration: ';
+            durationSpan.appendChild(durLabel);
+            const dayInput = document.createElement('input');
+            dayInput.type = 'number';
+            dayInput.placeholder = 'Days';
+            dayInput.min = '0';
+            dayInput.className = 'inline-input';
+            dayInput.value = days;
+            const hourInput = document.createElement('input');
+            hourInput.type = 'number';
+            hourInput.placeholder = 'Hours';
+            hourInput.min = '0';
+            hourInput.className = 'inline-input';
+            hourInput.value = hours;
+            const minuteInput = document.createElement('input');
+            minuteInput.type = 'number';
+            minuteInput.placeholder = 'Minutes';
+            minuteInput.min = '0';
+            minuteInput.max = '59';
+            minuteInput.className = 'inline-input';
+            minuteInput.value = minutes;
+            durationSpan.appendChild(dayInput);
+            durationSpan.appendChild(hourInput);
+            durationSpan.appendChild(minuteInput);
+
+            const respContainer = document.createElement('span');
+            const responsible = [...originalResp];
+
+            function addResp(user) {
+                const wrapper = document.createElement('span');
+                const img = document.createElement('img');
+                img.src = profileUrlTemplate.replace('__user__', encodeURIComponent(user));
+                img.alt = user;
+                img.className = 'profile-icon';
+                const rm = makeBtn(trashUrl, 'Remove');
+                rm.addEventListener('click', () => {
+                    wrapper.remove();
+                    const idx = responsible.indexOf(user);
+                    if (idx >= 0) responsible.splice(idx, 1);
+                    refreshDropdown();
+                });
+                wrapper.appendChild(img);
+                wrapper.appendChild(rm);
+                respContainer.appendChild(wrapper);
+            }
+
+            const addWrap = document.createElement('span');
+            addWrap.className = 'responsible-selector';
+            const addBtn = makeBtn(plusUrl, 'Add user');
+            const dropdown = document.createElement('div');
+            dropdown.className = 'dropdown';
+            dropdown.style.display = 'none';
+
+            function refreshDropdown() {
+                dropdown.innerHTML = '';
+                allUsers.filter(u => !responsible.includes(u)).forEach(u => {
+                    const a = document.createElement('a');
+                    a.href = '#';
+                    a.textContent = u;
+                    a.addEventListener('click', e => {
+                        e.preventDefault();
+                        responsible.push(u);
+                        addResp(u);
+                        dropdown.style.display = 'none';
+                        refreshDropdown();
+                    });
+                    dropdown.appendChild(a);
+                });
+            }
+
+            addBtn.addEventListener('click', () => {
+                dropdown.style.display = dropdown.style.display === 'block' ? 'none' : 'block';
+            });
+
+            addWrap.appendChild(addBtn);
+            addWrap.appendChild(dropdown);
+
+            originalResp.forEach(u => addResp(u));
+            refreshDropdown();
+
+            const save = makeBtn(diskUrl, 'Save');
+            const cancel = makeBtn(trashUrl, 'Cancel');
+
+            li.appendChild(typeSelect);
+            li.appendChild(durationSpan);
+            li.appendChild(respContainer);
+            li.appendChild(addWrap);
+            li.appendChild(save);
+            li.appendChild(cancel);
+
+            save.addEventListener('click', async () => {
+                await fetch(`/calendar/${entryId}/recurrence/update`, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        recurrence_index: rindex,
+                        type: typeSelect.value,
+                        offset_days: parseInt(dayInput.value || '0'),
+                        offset_hours: parseInt(hourInput.value || '0'),
+                        offset_minutes: parseInt(minuteInput.value || '0'),
+                        responsible: responsible
+                    })
+                });
+                location.reload();
+            });
+            cancel.addEventListener('click', () => location.reload());
+        });
+    });
 
     const descEdit = document.getElementById('edit-description');
     if (descEdit) {

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -182,21 +182,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const durationSpan = document.createElement('span');
             const durLabel = document.createElement('span');
-            durLabel.textContent = 'Duration: ';
+            durLabel.textContent = 'Offset: ';
             durationSpan.appendChild(durLabel);
             const dayInput = document.createElement('input');
             dayInput.type = 'number';
             dayInput.placeholder = 'Days';
             dayInput.min = '0';
             dayInput.className = 'inline-input';
-            dayInput.value = days;
+            if (days) dayInput.value = days;
             dayInput.style.width = '4ch';
             const hourInput = document.createElement('input');
             hourInput.type = 'number';
             hourInput.placeholder = 'Hours';
             hourInput.min = '0';
             hourInput.className = 'inline-input';
-            hourInput.value = hours;
+            if (hours) hourInput.value = hours;
             hourInput.style.width = '4ch';
             const minuteInput = document.createElement('input');
             minuteInput.type = 'number';
@@ -204,7 +204,7 @@ document.addEventListener('DOMContentLoaded', () => {
             minuteInput.min = '0';
             minuteInput.max = '59';
             minuteInput.className = 'inline-input';
-            minuteInput.value = minutes;
+            if (minutes) minuteInput.value = minutes;
             minuteInput.style.width = '4ch';
             durationSpan.appendChild(dayInput);
             durationSpan.appendChild(hourInput);

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -266,7 +266,7 @@ document.addEventListener('DOMContentLoaded', () => {
             refreshDropdown();
 
             const save = makeBtn(diskUrl, 'Save');
-            const cancel = makeBtn(trashUrl, 'Cancel');
+            const cancel = makeBtn(xUrl, 'Cancel');
 
             li.appendChild(typeSelect);
             li.appendChild(durationSpan);

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -117,6 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const plusUrl = "{{ url_for('static', path='plus.svg') }}";
     const profileUrlTemplate = "{{ request.url_for('profile_picture', username='__user__') }}";
     const allUsers = {{ all_users()|selectattr('username','ne','Viewer')|map(attribute='username')|list|tojson }};
+    const recurrenceTypes = {{ RecurrenceType|map(attribute='value')|list|tojson }};
 
     function makeBtn(url, alt) {
         const b = document.createElement('button');
@@ -171,13 +172,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const typeSelect = document.createElement('select');
             typeSelect.className = 'inline-input';
-            {% for t in RecurrenceType %}
-            const opt{{ loop.index0 }} = document.createElement('option');
-            opt{{ loop.index0 }}.value = "{{ t.value }}";
-            opt{{ loop.index0 }}.textContent = "{{ t.value }}";
-            if ("{{ t.value }}" === originalType) opt{{ loop.index0 }}.selected = true;
-            typeSelect.appendChild(opt{{ loop.index0 }});
-            {% endfor %}
+            recurrenceTypes.forEach(t => {
+                const opt = document.createElement('option');
+                opt.value = t;
+                opt.textContent = t;
+                if (t === originalType) opt.selected = true;
+                typeSelect.appendChild(opt);
+            });
 
             const durationSpan = document.createElement('span');
             const durLabel = document.createElement('span');
@@ -189,12 +190,14 @@ document.addEventListener('DOMContentLoaded', () => {
             dayInput.min = '0';
             dayInput.className = 'inline-input';
             dayInput.value = days;
+            dayInput.style.width = '4ch';
             const hourInput = document.createElement('input');
             hourInput.type = 'number';
             hourInput.placeholder = 'Hours';
             hourInput.min = '0';
             hourInput.className = 'inline-input';
             hourInput.value = hours;
+            hourInput.style.width = '4ch';
             const minuteInput = document.createElement('input');
             minuteInput.type = 'number';
             minuteInput.placeholder = 'Minutes';
@@ -202,6 +205,7 @@ document.addEventListener('DOMContentLoaded', () => {
             minuteInput.max = '59';
             minuteInput.className = 'inline-input';
             minuteInput.value = minutes;
+            minuteInput.style.width = '4ch';
             durationSpan.appendChild(dayInput);
             durationSpan.appendChild(hourInput);
             durationSpan.appendChild(minuteInput);
@@ -272,9 +276,10 @@ document.addEventListener('DOMContentLoaded', () => {
             li.appendChild(cancel);
 
             save.addEventListener('click', async () => {
-                await fetch(`/calendar/${entryId}/recurrence/update`, {
+                const resp = await fetch(`/calendar/${entryId}/recurrence/update`, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
+                    credentials: 'same-origin',
                     body: JSON.stringify({
                         recurrence_index: rindex,
                         type: typeSelect.value,
@@ -284,7 +289,11 @@ document.addEventListener('DOMContentLoaded', () => {
                         responsible: responsible
                     })
                 });
-                location.reload();
+                if (resp.ok) {
+                    location.reload();
+                } else {
+                    alert('Failed to update recurrence');
+                }
             });
             cancel.addEventListener('click', () => location.reload());
         });

--- a/tests/test_recurrence_update.py
+++ b/tests/test_recurrence_update.py
@@ -1,0 +1,69 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+    Offset,
+)
+
+
+def test_update_recurrence_responsible_and_offset(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+
+    client = TestClient(app_module.app)
+    client.post(
+        "/login",
+        data={"username": "Admin", "password": "admin"},
+        follow_redirects=False,
+    )
+
+    entry = CalendarEntry(
+        title="RecTest",
+        description="",
+        type=CalendarEntryType.Chore,
+        first_start=datetime(2000, 1, 1, 0, 0),
+        duration_seconds=60,
+        recurrences=[
+            Recurrence(
+                type=RecurrenceType.Weekly,
+                offset=Offset(exact_duration_seconds=3600),
+                responsible=["Alice"],
+            )
+        ],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    resp = client.post(
+        f"/calendar/{entry_id}/recurrence/update",
+        json={
+            "recurrence_index": 0,
+            "type": "Weekly",
+            "offset_days": 0,
+            "offset_hours": 2,
+            "offset_minutes": 30,
+            "responsible": ["Bob"],
+        },
+    )
+    assert resp.status_code == 200
+
+    updated = app_module.calendar_store.get(entry_id)
+    rec = updated.recurrences[0]
+    assert rec.responsible == ["Bob"]
+    assert rec.offset and rec.offset.exact_duration_seconds == 2 * 3600 + 30 * 60
+


### PR DESCRIPTION
## Summary
- Display responsible users' profile pictures next to each recurrence
- Add inline editing of recurrence type, duration, and responsible users
- Provide API endpoint to update recurrence details

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac69e8cd10832cbc780e37b3d73bad