### PR TITLE
Add dynamic instance limits with plus icons

### DIFF
--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -60,7 +60,7 @@
 {% if past_instances or upcoming_instances %}
 <h2>Instances</h2>
     {% if past_instances %}
-    <h3>Past</h3>
+    <h3>Past <a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}?past_entries={{ past_entries + 5 }}&upcoming_entries={{ upcoming_entries }}" class="icon-button"><img src="{{ url_for('static', path='plus.svg') }}" alt="Show more past instances" class="icon"></a></h3>
     <ul class="time-list">
         {% for period, completion, can_remove, is_skipped, responsible in past_instances %}
         <li>
@@ -79,7 +79,7 @@
     </ul>
     {% endif %}
     {% if upcoming_instances %}
-    <h3>Upcoming</h3>
+    <h3>Upcoming <a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}?past_entries={{ past_entries }}&upcoming_entries={{ upcoming_entries + 5 }}" class="icon-button"><img src="{{ url_for('static', path='plus.svg') }}" alt="Show more upcoming instances" class="icon"></a></h3>
     <ul class="time-list">
         {% for period, completion, can_remove, is_skipped, responsible in upcoming_instances %}
         <li>


### PR DESCRIPTION
## Summary
- Allow CalendarEntry view to show more past/upcoming instances based on `past_entries` and `upcoming_entries` query params instead of fixed constant
- Add plus icons beside Past and Upcoming headings to increment respective query parameters by 5

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac870361e4832c9fb5624738a55e8e