### PR TITLE
feat: add managers to calendar entries

### DIFF
--- a/choretracker/calendar.py
+++ b/choretracker/calendar.py
@@ -53,7 +53,7 @@ class CalendarEntry(SQLModel, table=True):
     recurrences: List[Recurrence] = Field(default_factory=list, sa_column=Column(JSON))
     none_after: Optional[datetime] = None
     responsible: List[str] = Field(default_factory=list, sa_column=Column(JSON))
-    owner: str = ""
+    managers: List[str] = Field(default_factory=list, sa_column=Column(JSON))
 
     @property
     def duration(self) -> timedelta:
@@ -95,6 +95,7 @@ class CalendarEntryStore:
             entry.recurrences = new_data.recurrences
             entry.none_after = new_data.none_after
             entry.responsible = new_data.responsible
+            entry.managers = new_data.managers
             session.add(entry)
             session.commit()
 

--- a/choretracker/calendar.py
+++ b/choretracker/calendar.py
@@ -69,6 +69,8 @@ class CalendarEntryStore:
         self.engine = engine
 
     def create(self, entry: CalendarEntry) -> None:
+        if not entry.managers:
+            raise ValueError("CalendarEntry must have at least one manager")
         with Session(self.engine) as session:
             session.add(entry)
             session.commit()
@@ -84,6 +86,8 @@ class CalendarEntryStore:
             return entry
 
     def update(self, entry_id: int, new_data: CalendarEntry) -> None:
+        if not new_data.managers:
+            raise ValueError("CalendarEntry must have at least one manager")
         with Session(self.engine) as session:
             entry = session.get(CalendarEntry, entry_id)
             if not entry:

--- a/choretracker/templates/calendar/form.html
+++ b/choretracker/templates/calendar/form.html
@@ -64,6 +64,22 @@
 
     <div class="field">
         <div class="label-row">
+            <span>Managers</span>
+            <span class="help" data-help="People who can edit this entry">?</span>
+        </div>
+        <div class="responsible-selector">
+            <button type="button" id="add-managers">Add</button>
+            <div class="dropdown" id="managers-dropdown">
+                {% for u in all_users() %}
+                <a href="#" data-user="{{ u.username }}">{{ u.username }}</a>
+                {% endfor %}
+            </div>
+        </div>
+        <ul id="managers-list"></ul>
+    </div>
+
+    <div class="field">
+        <div class="label-row">
             <span>Responsible</span>
             <span class="help" data-help="People responsible for this entry">?</span>
         </div>
@@ -291,11 +307,17 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     });
 
-    const entryManager = createResponsibleManager(
+    const entryRespManager = createResponsibleManager(
         document.getElementById('add-responsible'),
         document.getElementById('responsible-dropdown'),
         document.getElementById('responsible-list'),
         'responsible'
+    );
+    const entryManagersManager = createResponsibleManager(
+        document.getElementById('add-managers'),
+        document.getElementById('managers-dropdown'),
+        document.getElementById('managers-list'),
+        'managers'
     );
 
     {% if entry_data %}
@@ -314,7 +336,8 @@ document.addEventListener('DOMContentLoaded', function () {
         document.getElementById('none_after').value = data.none_after.slice(0,16);
     }
     data.recurrences.forEach(r => addRecurrenceItem(r));
-    data.responsible.forEach(u => entryManager.addUser(u));
+    data.responsible.forEach(u => entryRespManager.addUser(u));
+    data.managers.forEach(u => entryManagersManager.addUser(u));
     {% endif %}
 
     const form = document.getElementById('entry-form');

--- a/choretracker/templates/calendar/form.html
+++ b/choretracker/templates/calendar/form.html
@@ -319,6 +319,9 @@ document.addEventListener('DOMContentLoaded', function () {
         document.getElementById('managers-list'),
         'managers'
     );
+    {% if not entry_data %}
+    entryManagersManager.addUser('{{ current_user }}');
+    {% endif %}
 
     {% if entry_data %}
     const data = {{ entry_data | tojson }};
@@ -361,6 +364,11 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!validateDuration()) {
             e.preventDefault();
             durationInputs[0].reportValidity();
+            return;
+        }
+        if (entryManagersManager.list.querySelectorAll('li').length === 0) {
+            e.preventDefault();
+            alert('At least one manager required');
             return;
         }
         document.querySelectorAll('input[name="recurrence_responsible[]"]').forEach(el => el.remove());

--- a/choretracker/templates/calendar/list.html
+++ b/choretracker/templates/calendar/list.html
@@ -8,9 +8,7 @@
     {% for entry in entries %}
     <li>
         <a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a>
-        {% set write_perm = WRITE_PERMS[entry_type] %}
-        {% set edit_perm = EDIT_OTHER_PERMS[entry_type] %}
-        {% if user_has(current_user, write_perm) and (entry.owner == current_user or user_has(current_user, edit_perm)) %}
+        {% if current_user in entry.managers or user_has(current_user, 'admin') %}
         <a href="{{ url_for('edit_calendar_entry', entry_id=entry.id) }}" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></a>
         <form method="post" action="{{ url_for('delete_calendar_entry', entry_id=entry.id) }}" style="display:inline" onsubmit="return confirm('Are you sure you want to delete this entry?');">
             <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -73,7 +73,12 @@
         <button type="button" id="edit-responsible" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
         {% endif %}
     </span></dt>
-    <dt>Owner</dt><dd>{{ entry.owner }}</dd>
+    <dt>Managers</dt>
+    <dd>
+        {% for user in entry.managers %}
+        <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
+        {% endfor %}
+    </dd>
 </dl>
 {% if past_instances or upcoming_instances %}
 <h2>Instances</h2>

--- a/tests/test_calendar_entry_instances.py
+++ b/tests/test_calendar_entry_instances.py
@@ -41,6 +41,7 @@ def test_instances_past_and_upcoming(tmp_path, monkeypatch):
             Recurrence(type=RecurrenceType.Weekly, skipped_instances=[1])
         ],
         responsible=["Bob"],
+        managers=["Admin"],
     )
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[0].id

--- a/tests/test_calendar_list_disambiguation.py
+++ b/tests/test_calendar_list_disambiguation.py
@@ -25,6 +25,7 @@ def test_duplicate_titles_disambiguated(tmp_path, monkeypatch):
         type=CalendarEntryType.Event,
         first_start=datetime(2025, 8, 22, 8, 0, 0),
         duration_seconds=60,
+        managers=["Admin"],
     )
     second = CalendarEntry(
         title="Guinea salad",
@@ -32,6 +33,7 @@ def test_duplicate_titles_disambiguated(tmp_path, monkeypatch):
         type=CalendarEntryType.Event,
         first_start=datetime(2025, 8, 23, 8, 0, 0),
         duration_seconds=60,
+        managers=["Admin"],
     )
     app_module.calendar_store.create(first)
     app_module.calendar_store.create(second)

--- a/tests/test_delegate_instance.py
+++ b/tests/test_delegate_instance.py
@@ -30,6 +30,7 @@ def test_delegate_instance(tmp_path, monkeypatch):
         duration_seconds=60,
         recurrences=[Recurrence(type=RecurrenceType.Weekly)],
         responsible=["Admin"],
+        managers=["Admin"],
     )
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[0].id

--- a/tests/test_description_markdown.py
+++ b/tests/test_description_markdown.py
@@ -25,6 +25,7 @@ def test_description_rendered_as_markdown(tmp_path, monkeypatch):
         type=CalendarEntryType.Event,
         first_start=datetime(2025, 1, 1, 0, 0, 0),
         duration_seconds=60,
+        managers=["Admin"],
     )
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[-1].id

--- a/tests/test_entry_managers.py
+++ b/tests/test_entry_managers.py
@@ -1,0 +1,54 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import CalendarEntry, CalendarEntryType
+
+
+def test_edit_permissions(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+
+    client = TestClient(app_module.app)
+
+    # create additional users
+    app_module.user_store.create("Manager", "manager", None, set())
+    app_module.user_store.create("Bob", "bob", None, set())
+
+    entry = CalendarEntry(
+        title="Test",
+        description="",
+        type=CalendarEntryType.Event,
+        first_start=datetime(2000, 1, 1, 0, 0),
+        duration_seconds=60,
+        managers=["Manager"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    # Manager can edit
+    client.post("/login", data={"username": "Manager", "password": "manager"}, follow_redirects=False)
+    resp = client.post(f"/calendar/{entry_id}/update", json={"title": "Updated"})
+    assert resp.status_code == 200
+    assert app_module.calendar_store.get(entry_id).title == "Updated"
+
+    # Non-manager without admin cannot edit
+    client.post("/login", data={"username": "Bob", "password": "bob"}, follow_redirects=False)
+    resp = client.post(f"/calendar/{entry_id}/update", json={"title": "Hack"}, follow_redirects=False)
+    assert resp.status_code == 303
+    assert app_module.calendar_store.get(entry_id).title == "Updated"
+
+    # Admin can edit even if not manager
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+    resp = client.post(f"/calendar/{entry_id}/update", json={"title": "AdminUpdate"})
+    assert resp.status_code == 200
+    assert app_module.calendar_store.get(entry_id).title == "AdminUpdate"

--- a/tests/test_entry_managers.py
+++ b/tests/test_entry_managers.py
@@ -52,3 +52,54 @@ def test_edit_permissions(tmp_path, monkeypatch):
     resp = client.post(f"/calendar/{entry_id}/update", json={"title": "AdminUpdate"})
     assert resp.status_code == 200
     assert app_module.calendar_store.get(entry_id).title == "AdminUpdate"
+
+
+def test_manager_prepopulated_and_required(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+
+    client = TestClient(app_module.app)
+
+    # Login as admin to access creation form
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    # Form should prepopulate managers with current user
+    resp = client.get("/calendar/new/Event")
+    assert resp.status_code == 200
+    assert "entryManagersManager.addUser('Admin')" in resp.text
+
+    # Missing managers should be rejected
+    form_data = {
+        "title": "Test", "type": "Event", "first_start": "2000-01-01T00:00", "duration_minutes": "1"
+    }
+    resp = client.post("/calendar/new", data=form_data)
+    assert resp.status_code == 400
+
+
+def test_update_rejects_empty_managers(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+
+    client = TestClient(app_module.app)
+
+    entry = CalendarEntry(
+        title="Test",
+        description="",
+        type=CalendarEntryType.Event,
+        first_start=datetime(2000, 1, 1, 0, 0),
+        duration_seconds=60,
+        managers=["Admin"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+    resp = client.post(f"/calendar/{entry_id}/update", json={"managers": []})
+    assert resp.status_code == 400
+    assert app_module.calendar_store.get(entry_id).managers == ["Admin"]

--- a/tests/test_hide_due_when_completed.py
+++ b/tests/test_hide_due_when_completed.py
@@ -30,6 +30,7 @@ def test_due_not_shown_when_completed(tmp_path, monkeypatch):
         type=CalendarEntryType.Chore,
         first_start=now - timedelta(minutes=5),
         duration_seconds=3600,
+        managers=["Admin"],
     )
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[0].id

--- a/tests/test_inline_edit.py
+++ b/tests/test_inline_edit.py
@@ -27,6 +27,7 @@ def test_inline_update(tmp_path, monkeypatch):
         type=CalendarEntryType.Event,
         first_start=datetime(2000, 1, 1, 0, 0),
         duration_seconds=60,
+        managers=["Admin"],
     )
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[0].id

--- a/tests/test_recurrence_add_delete.py
+++ b/tests/test_recurrence_add_delete.py
@@ -35,6 +35,7 @@ def test_add_recurrence(tmp_path, monkeypatch):
         first_start=datetime(2000, 1, 1, 0, 0),
         duration_seconds=60,
         recurrences=[],
+        managers=["Admin"],
     )
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[0].id
@@ -71,6 +72,7 @@ def test_delete_recurrence(tmp_path, monkeypatch):
             Recurrence(type=RecurrenceType.Weekly),
             Recurrence(type=RecurrenceType.MonthlyDayOfMonth),
         ],
+        managers=["Admin"],
     )
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[0].id

--- a/tests/test_recurrence_update.py
+++ b/tests/test_recurrence_update.py
@@ -45,6 +45,7 @@ def test_update_recurrence_responsible_and_offset(tmp_path, monkeypatch):
                 responsible=["Alice"],
             )
         ],
+        managers=["Admin"],
     )
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[0].id

--- a/tests/test_timeperiod_completed_by.py
+++ b/tests/test_timeperiod_completed_by.py
@@ -34,6 +34,7 @@ def test_completed_by_username_shown(tmp_path, monkeypatch):
         first_start=datetime(2000, 1, 1, 8, 0, 0),
         duration_seconds=60,
         recurrences=[Recurrence(type=RecurrenceType.Weekly)],
+        managers=["Admin"],
     )
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[0].id


### PR DESCRIPTION
## Summary
- replace single owner with list of managers on calendar entries
- restrict editing to managers or admin users
- allow selecting managers in entry form and show them on pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac938e20b8832c89c8092f4c55308c