### PR TITLE
Remove edit_others permission checks

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -55,16 +55,13 @@ completion_store = ChoreCompletionStore(engine)
 ALL_PERMISSIONS = [
     "chores.read",
     "chores.write",
-    "chores.edit_others",
     "chores.complete_on_time",
     "chores.complete_overdue",
     "chores.override_complete",
     "events.read",
     "events.write",
-    "events.edit_others",
     "reminders.read",
     "reminders.write",
-    "reminders.edit_others",
     "iam",
 ]
 
@@ -80,12 +77,6 @@ WRITE_PERMS = {
     CalendarEntryType.Chore: "chores.write",
 }
 
-EDIT_OTHER_PERMS = {
-    CalendarEntryType.Event: "events.edit_others",
-    CalendarEntryType.Reminder: "reminders.edit_others",
-    CalendarEntryType.Chore: "chores.edit_others",
-}
-
 app = FastAPI()
 
 BASE_PATH = Path(__file__).resolve().parent
@@ -96,7 +87,6 @@ templates.env.globals["all_users"] = lambda: sorted(
 )
 templates.env.globals["user_has"] = user_store.has_permission
 templates.env.globals["WRITE_PERMS"] = WRITE_PERMS
-templates.env.globals["EDIT_OTHER_PERMS"] = EDIT_OTHER_PERMS
 templates.env.globals["timedelta"] = timedelta
 templates.env.globals["LOGOUT_DURATION"] = LOGOUT_DURATION
 def format_datetime(dt: datetime | None, include_day: bool = False) -> str:

--- a/choretracker/templates/users/form.html
+++ b/choretracker/templates/users/form.html
@@ -84,10 +84,6 @@
                 <span>Create</span>
             </label>
             <label class="checkbox">
-                <input type="checkbox" name="chores.edit_others" {% if user and 'chores.edit_others' in user.permissions %}checked{% endif %}>
-                <span>Edit others'</span>
-            </label>
-            <label class="checkbox">
                 <input type="checkbox" name="chores.complete_on_time" {% if user and 'chores.complete_on_time' in user.permissions %}checked{% endif %}>
                 <span>Complete on time</span>
             </label>
@@ -110,10 +106,6 @@
                 <input type="checkbox" name="events.write" {% if user and 'events.write' in user.permissions %}checked{% endif %}>
                 <span>Create</span>
             </label>
-            <label class="checkbox">
-                <input type="checkbox" name="events.edit_others" {% if user and 'events.edit_others' in user.permissions %}checked{% endif %}>
-                <span>Edit others'</span>
-            </label>
         </div>
         <div class="group">
             <h3>Reminders</h3>
@@ -124,10 +116,6 @@
             <label class="checkbox">
                 <input type="checkbox" name="reminders.write" {% if user and 'reminders.write' in user.permissions %}checked{% endif %}>
                 <span>Create</span>
-            </label>
-            <label class="checkbox">
-                <input type="checkbox" name="reminders.edit_others" {% if user and 'reminders.edit_others' in user.permissions %}checked{% endif %}>
-                <span>Edit others'</span>
             </label>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Remove all `*.edit_others` permissions and related mappings
- Drop `Edit others` checkboxes from the user permissions form

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac9eace730832cb5df39b65ec7423e