### PR TITLE
Show profile pictures on user list and refine permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,6 @@ docker run -e CHORETRACKER_DB=/data/choretracker.db -v $(pwd)/data:/data -p 8000
 ```
 
 A new database is automatically populated with an `Admin` user (password
-`admin`, PIN `0000`) that has both `admin` and `iam` permissions.
+`admin`, PIN `0000`) that has the `admin` permission.
+The `admin` permission grants all actions, including those normally
+requiring `iam`.

--- a/choretracker/templates/users/form.html
+++ b/choretracker/templates/users/form.html
@@ -61,7 +61,7 @@
     <h2>Permissions</h2>
     <div class="group">
         <div class="group">
-            <h3>User Management</h3>
+            <h3>Management</h3>
             {% if user_has(request.session.get('user'), 'admin') %}
             <label class="checkbox">
                 <input type="checkbox" name="admin" {% if user and 'admin' in user.permissions %}checked{% endif %}>

--- a/choretracker/templates/users/list.html
+++ b/choretracker/templates/users/list.html
@@ -7,7 +7,8 @@
 <ul>
 {% for u in users %}
     <li>
-        {{ u.username }}{% if 'admin' in u.permissions %} (admin){% endif %}{% if 'iam' in u.permissions %} (iam){% endif %}
+        <img src="{{ url_for('profile_picture', username=u.username) }}" alt="{{ u.username }}" class="profile-icon">
+        {{ u.username }}{% if 'admin' in u.permissions %} (admin){% endif %}
         <a href="{{ url_for('edit_user', username=u.username) }}"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></a>
         <form method="post" action="{{ url_for('delete_user', username=u.username) }}" style="display:inline">
             <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>

--- a/choretracker/users.py
+++ b/choretracker/users.py
@@ -173,7 +173,7 @@ def init_db(engine) -> None:
                 username="Admin",
                 password_hash=hash_secret("admin"),
                 pin_hash=hash_secret("0000"),
-                permissions=["admin", "iam"],
+                permissions=["admin"],
             )
             session.add(admin)
         viewer_perms = ["chores.read", "events.read", "reminders.read"]

--- a/tests/test_user_list_profile_picture.py
+++ b/tests/test_user_list_profile_picture.py
@@ -1,0 +1,34 @@
+import importlib
+import sys
+from pathlib import Path
+import re
+
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_user_list_includes_profile_pictures(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+
+    client = TestClient(app_module.app)
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    # Create a user with only iam permission
+    app_module.user_store.create("Manager", None, None, {"iam"})
+
+    resp = client.get("/users")
+    text = resp.text
+
+    assert "/users/Admin/profile_picture" in text
+    assert "/users/Manager/profile_picture" in text
+    assert "(admin)" in text
+    assert "(iam)" not in text
+
+    # Profile picture appears before username for Manager
+    assert re.search(r"<li>\s*<img src=\"[^\"]*/users/Manager/profile_picture\"[^>]*>\s*Manager", text)


### PR DESCRIPTION
## Summary
- Show each user's profile picture next to their name in the user list and stop showing `(iam)` markers
- Default Admin no longer receives the `iam` permission; `admin` already grants full access
- Rename "User Management" permission section to "Management"
- Document new default Admin permissions
- Add test covering profile picture display and permission label removal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca49310c8832c8b6b19794ab5c01a