### PR TITLE
Logout missing session user

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -193,7 +193,12 @@ app.mount("/static", StaticFiles(directory=str(BASE_PATH / "static")), name="sta
 
 def require_permission(request: Request, permission: str) -> None:
     username = request.session.get("user")
-    if not username or not user_store.has_permission(username, permission):
+    if not username or not user_store.get(username):
+        request.session.clear()
+        raise HTTPException(
+            status_code=303, headers={"Location": str(request.url_for("login"))}
+        )
+    if not user_store.has_permission(username, permission):
         request.session["flash"] = "You are not allowed to perform that action."
         raise HTTPException(
             status_code=303, headers={"Location": str(request.url_for("index"))}

--- a/tests/test_session_invalid_user.py
+++ b/tests/test_session_invalid_user.py
@@ -18,14 +18,20 @@ def test_deleted_user_logs_out(tmp_path, monkeypatch):
     client = TestClient(app_module.app)
 
     # Create and login as a temporary user
-    app_module.user_store.create("Temp", "temp", None, set())
-    client.post("/login", data={"username": "Temp", "password": "temp"}, follow_redirects=False)
+    app_module.user_store.create("Temp", "temp", None, {"iam"})
+    client.post(
+        "/login", data={"username": "Temp", "password": "temp"}, follow_redirects=False
+    )
+
+    # Ensure the session remains active before deletion by accessing a protected page
+    resp = client.get("/users", follow_redirects=False)
+    assert resp.status_code == 200
 
     # Remove the user from the store
     app_module.user_store.delete("Temp")
 
     # Access a protected endpoint; should redirect to login and clear session
-    resp = client.get("/", follow_redirects=False)
+    resp = client.get("/users", follow_redirects=False)
     assert resp.status_code in (303, 307)
     assert resp.headers["location"] == "/login"
 


### PR DESCRIPTION
## Summary
- logout and redirect to login when session references a non-existent user
- add regression test for accessing protected endpoints after user deletion

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad0b2b5c30832cae32227cbc95d163