### PR TITLE
Implement standard time range summaries across calendar views

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -172,7 +172,7 @@ def time_range_summary(start: datetime, end: datetime | None) -> str:
     start = start.replace(second=0, microsecond=0)
     start_str = start.strftime("%a %Y-%m-%d %H:%M")
     if end is None:
-        return f"(From {start_str}, indefinitely)"
+        return f"From {start_str}, indefinitely"
     end = end.replace(second=0, microsecond=0)
     if start.year != end.year:
         end_fmt = "%a %Y-%m-%d"
@@ -183,7 +183,7 @@ def time_range_summary(start: datetime, end: datetime | None) -> str:
     if start.hour != end.hour or start.minute != end.minute:
         end_fmt = f"{end_fmt + ' ' if end_fmt else ''}%H:%M"
     end_str = end.strftime(end_fmt).strip()
-    return f"({start_str} to {end_str})"
+    return f"{start_str} to {end_str}"
 
 
 templates.env.globals["time_range_summary"] = time_range_summary
@@ -589,7 +589,7 @@ async def list_calendar_entries(request: Request, entry_type: str):
     for entry in entries:
         if counts[entry.title] > 1:
             start, end = entry_time_bounds(entry)
-            entry.title = f"{entry.title} {time_range_summary(start, end)}"
+            entry.title = f"{entry.title} ({time_range_summary(start, end)})"
     current_user = request.session.get("user")
     return templates.TemplateResponse(
         "calendar/list.html",

--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -168,27 +168,40 @@ def b64encode_filter(s: str) -> str:
 
 templates.env.filters["b64encode"] = b64encode_filter
 
-
-def format_time_range(period: TimePeriod) -> str:
-    start = period.start.replace(second=0, microsecond=0)
-    end = period.end.replace(second=0, microsecond=0)
-    start_str = start.strftime("%Y-%m-%d %H:%M")
+def time_range_summary(start: datetime, end: datetime | None) -> str:
+    start = start.replace(second=0, microsecond=0)
+    start_str = start.strftime("%a %Y-%m-%d %H:%M")
+    if end is None:
+        return f"(From {start_str}, indefinitely)"
+    end = end.replace(second=0, microsecond=0)
     if start.year != end.year:
-        end_fmt = "%Y-%m-%d %H:%M"
-    elif start.month != end.month:
-        end_fmt = "%m-%d %H:%M"
-    elif start.day != end.day:
-        end_fmt = "%d %H:%M"
-    elif start.hour != end.hour:
-        end_fmt = "%H:%M"
+        end_fmt = "%a %Y-%m-%d"
+    elif start.month != end.month or start.day != end.day:
+        end_fmt = "%a %m-%d"
     else:
-        end_fmt = "%M"
-    end_str = end.strftime(end_fmt)
-    return f"{start_str} - {end_str}"
+        end_fmt = ""
+    if start.hour != end.hour or start.minute != end.minute:
+        end_fmt = f"{end_fmt + ' ' if end_fmt else ''}%H:%M"
+    end_str = end.strftime(end_fmt).strip()
+    return f"({start_str} to {end_str})"
 
 
-templates.env.filters["format_time_range"] = format_time_range
+templates.env.globals["time_range_summary"] = time_range_summary
 app.mount("/static", StaticFiles(directory=str(BASE_PATH / "static")), name="static")
+
+
+def entry_time_bounds(entry: CalendarEntry) -> tuple[datetime, datetime | None]:
+    periods = enumerate_time_periods(entry)
+    first = next(periods, None)
+    if not first:
+        return (entry.first_start, None)
+    start = first.start
+    end = first.end
+    if entry.recurrences and entry.none_after is None:
+        return (start, None)
+    for p in periods:
+        end = p.end
+    return (start, end)
 
 
 def require_permission(request: Request, permission: str) -> None:
@@ -575,7 +588,8 @@ async def list_calendar_entries(request: Request, entry_type: str):
     counts = Counter(e.title for e in entries)
     for entry in entries:
         if counts[entry.title] > 1:
-            entry.title = f"{entry.title} ({format_datetime(entry.first_start, include_day=True)})"
+            start, end = entry_time_bounds(entry)
+            entry.title = f"{entry.title} {time_range_summary(start, end)}"
     current_user = request.session.get("user")
     return templates.TemplateResponse(
         "calendar/list.html",
@@ -596,6 +610,7 @@ async def view_calendar_entry(
     if not entry:
         raise HTTPException(status_code=404)
     require_entry_read_permission(request, entry.type)
+    entry_start, entry_end = entry_time_bounds(entry)
     current_user = request.session.get("user")
     comps_list = completion_store.list_for_entry(entry_id)
     comp_map = {(c.recurrence_index, c.instance_index): c for c in comps_list}
@@ -660,6 +675,8 @@ async def view_calendar_entry(
             "upcoming_entries": upcoming_entries,
             "CalendarEntryType": CalendarEntryType,
             "RecurrenceType": RecurrenceType,
+            "entry_start": entry_start,
+            "entry_end": entry_end,
         },
     )
 

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -5,7 +5,7 @@
 {% block content %}
 <h1><a href="{{ request.url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a> instance</h1>
 <div class="time-range">
-    <span>{{ period|format_time_range }}</span>
+    <span>{{ time_range_summary(period.start, period.end) }}</span>
     {% for user in responsible %}
     <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
     {% endfor %}

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -13,6 +13,7 @@
     </form>
     {% endif %}
 </h1>
+<p class="time-range">{{ time_range_summary(entry_start, entry_end) }}</p>
 <div class="description" id="description-container">
     <div id="description-text">{{ entry.description|markdown }}</div>
     {% if can_edit %}
@@ -92,7 +93,7 @@
     <ul class="time-list">
         {% for period, completion, can_remove, is_skipped, responsible in past_instances %}
         <li>
-            <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">Due {{ period.end|format_datetime(include_day=True) }}</a>
+            <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ time_range_summary(period.start, period.end) }}</a>
             {% for user in responsible %}
             <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
             {% endfor %}
@@ -111,7 +112,7 @@
     <ul class="time-list">
         {% for period, completion, can_remove, is_skipped, responsible in upcoming_instances %}
         <li>
-            <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">Due {{ period.end|format_datetime(include_day=True) }}</a>
+            <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ time_range_summary(period.start, period.end) }}</a>
             {% for user in responsible %}
             <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
             {% endfor %}

--- a/tests/test_calendar_entry_instances.py
+++ b/tests/test_calendar_entry_instances.py
@@ -55,26 +55,23 @@ def test_instances_past_and_upcoming(tmp_path, monkeypatch):
     assert "Past" in text and "Upcoming" in text
     # early completion should show under Past and be linked
     assert (
-        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/2">Due Saturday 2000-01-22 01:00</a>'
-        in text
+        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/2">(Sat 2000-01-22 00:00 to 01:00)</a>' in text
     )
     # skipped past instance is listed with annotation and responsible profile
     assert (
-        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/1">Due Saturday 2000-01-15 01:00</a>'
-        in text
+        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/1">(Sat 2000-01-15 00:00 to 01:00)</a>' in text
     )
     assert "(skipped)" in text
     # first upcoming instance is linked
     assert (
-        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/3">Due Saturday 2000-01-29 01:00</a>'
-        in text
+        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/3">(Sat 2000-01-29 00:00 to 01:00)</a>' in text
     )
     # profile icons for completed and responsible users displayed
     assert "/users/Admin/profile_picture" in text
     assert "/users/Bob/profile_picture" in text
     # Responsible icon should appear before completion details
     line = re.search(
-        rf'<a href="http://testserver/calendar/entry/{entry_id}/period/0/2">Due Saturday 2000-01-22 01:00</a>(.*?)</li>',
+        rf'<a href="http://testserver/calendar/entry/{entry_id}/period/0/2">\(Sat 2000-01-22 00:00 to 01:00\)</a>(.*?)</li>',
         text,
         re.DOTALL,
     ).group(1)

--- a/tests/test_calendar_entry_instances.py
+++ b/tests/test_calendar_entry_instances.py
@@ -55,23 +55,23 @@ def test_instances_past_and_upcoming(tmp_path, monkeypatch):
     assert "Past" in text and "Upcoming" in text
     # early completion should show under Past and be linked
     assert (
-        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/2">(Sat 2000-01-22 00:00 to 01:00)</a>' in text
+        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/2">Sat 2000-01-22 00:00 to 01:00</a>' in text
     )
     # skipped past instance is listed with annotation and responsible profile
     assert (
-        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/1">(Sat 2000-01-15 00:00 to 01:00)</a>' in text
+        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/1">Sat 2000-01-15 00:00 to 01:00</a>' in text
     )
     assert "(skipped)" in text
     # first upcoming instance is linked
     assert (
-        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/3">(Sat 2000-01-29 00:00 to 01:00)</a>' in text
+        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/3">Sat 2000-01-29 00:00 to 01:00</a>' in text
     )
     # profile icons for completed and responsible users displayed
     assert "/users/Admin/profile_picture" in text
     assert "/users/Bob/profile_picture" in text
     # Responsible icon should appear before completion details
     line = re.search(
-        rf'<a href="http://testserver/calendar/entry/{entry_id}/period/0/2">\(Sat 2000-01-22 00:00 to 01:00\)</a>(.*?)</li>',
+        rf'<a href="http://testserver/calendar/entry/{entry_id}/period/0/2">Sat 2000-01-22 00:00 to 01:00</a>(.*?)</li>',
         text,
         re.DOTALL,
     ).group(1)

--- a/tests/test_calendar_list_disambiguation.py
+++ b/tests/test_calendar_list_disambiguation.py
@@ -39,5 +39,5 @@ def test_duplicate_titles_disambiguated(tmp_path, monkeypatch):
     app_module.calendar_store.create(second)
 
     response = client.get("/calendar/list/Event")
-    assert "Guinea salad (Friday 2025-08-22 08:00)" in response.text
-    assert "Guinea salad (Saturday 2025-08-23 08:00)" in response.text
+    assert "Guinea salad (Fri 2025-08-22 08:00 to 08:01)" in response.text
+    assert "Guinea salad (Sat 2025-08-23 08:00 to 08:01)" in response.text


### PR DESCRIPTION
## Summary
- Add `time_range_summary` helper and `entry_time_bounds` to compute consistent time range descriptions
- Show standard time range summaries on list, entry, and instance views
- Adjust tests for new time range format

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad1e8b8844832c9b7471f62473c68c