### PR TITLE
Split calendar entries into active and past lists

### DIFF
--- a/choretracker/templates/calendar/list.html
+++ b/choretracker/templates/calendar/list.html
@@ -4,8 +4,10 @@
 
 {% block content %}
 <h1>{{ entry_type.value }}s{% if user_has(current_user, WRITE_PERMS[entry_type]) %}<a href="{{ url_for('new_calendar_entry', entry_type=entry_type.value) }}" class="icon-button"><img src="{{ url_for('static', path='plus.svg') }}" alt="Add" class="icon"></a>{% endif %}</h1>
+
+<h2>Active</h2>
 <ul>
-    {% for entry in entries %}
+    {% for entry in active_entries %}
     <li>
         <a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a>
         {% if current_user in entry.managers or user_has(current_user, 'admin') %}
@@ -16,7 +18,24 @@
         {% endif %}
     </li>
     {% else %}
-    <li>No entries found.</li>
+    <li>No active entries found.</li>
+    {% endfor %}
+</ul>
+
+<h2>Past</h2>
+<ul>
+    {% for entry in past_entries %}
+    <li>
+        <a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a>
+        {% if current_user in entry.managers or user_has(current_user, 'admin') %}
+        <a href="{{ url_for('edit_calendar_entry', entry_id=entry.id) }}" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></a>
+        <form method="post" action="{{ url_for('delete_calendar_entry', entry_id=entry.id) }}" style="display:inline" onsubmit="return confirm('Are you sure you want to delete this entry?');">
+            <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
+        </form>
+        {% endif %}
+    </li>
+    {% else %}
+    <li>No past entries found.</li>
     {% endfor %}
 </ul>
 {% endblock %}

--- a/tests/test_calendar_list_active_past.py
+++ b/tests/test_calendar_list_active_past.py
@@ -1,0 +1,74 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+# Ensure project root is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import CalendarEntry, CalendarEntryType
+
+
+def test_list_active_and_past(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    app_module = importlib.import_module("choretracker.app")
+    client = TestClient(app_module.app)
+
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    now = datetime.now()
+    active_newer = CalendarEntry(
+        title="Future 2",
+        description="",
+        type=CalendarEntryType.Event,
+        first_start=now + timedelta(days=2),
+        duration_seconds=60,
+        managers=["Admin"],
+    )
+    active_older = CalendarEntry(
+        title="Future 1",
+        description="",
+        type=CalendarEntryType.Event,
+        first_start=now + timedelta(days=1),
+        duration_seconds=60,
+        managers=["Admin"],
+    )
+    past_newer = CalendarEntry(
+        title="Past 1",
+        description="",
+        type=CalendarEntryType.Event,
+        first_start=now - timedelta(days=1),
+        duration_seconds=60,
+        managers=["Admin"],
+    )
+    past_older = CalendarEntry(
+        title="Past 2",
+        description="",
+        type=CalendarEntryType.Event,
+        first_start=now - timedelta(days=2),
+        duration_seconds=60,
+        managers=["Admin"],
+    )
+    app_module.calendar_store.create(active_newer)
+    app_module.calendar_store.create(active_older)
+    app_module.calendar_store.create(past_newer)
+    app_module.calendar_store.create(past_older)
+
+    response = client.get("/calendar/list/Event")
+    text = response.text
+    assert "<h2>Active</h2>" in text
+    assert "<h2>Past</h2>" in text
+    active_idx = text.index("<h2>Active</h2>")
+    past_idx = text.index("<h2>Past</h2>")
+    assert active_idx < past_idx
+    idx_future2 = text.index("Future 2")
+    idx_future1 = text.index("Future 1")
+    assert idx_future2 < idx_future1
+    idx_past1 = text.index("Past 1")
+    idx_past2 = text.index("Past 2")
+    assert idx_past1 < idx_past2
+    assert idx_future2 < past_idx
+    assert idx_past1 > past_idx


### PR DESCRIPTION
## Summary
- Separate calendar entry lists into Active and Past sections
- Sort sections by first instance start time, newest first
- Test list page for proper active/past classification and ordering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad2a38b4c4832c9a79e282d8f25831