### PR TITLE
Link split calendar entries with previous/next references

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -623,6 +623,17 @@ async def view_calendar_entry(
         raise HTTPException(status_code=404)
     require_entry_read_permission(request, entry.type)
     entry_start, entry_end = entry_time_bounds(entry)
+    prev_entry = (
+        calendar_store.get(entry.previous_entry) if entry.previous_entry else None
+    )
+    next_entry = (
+        calendar_store.get(entry.next_entry) if entry.next_entry else None
+    )
+    prev_start = prev_end = next_start = next_end = None
+    if prev_entry:
+        prev_start, prev_end = entry_time_bounds(prev_entry)
+    if next_entry:
+        next_start, next_end = entry_time_bounds(next_entry)
     current_user = request.session.get("user")
     comps_list = completion_store.list_for_entry(entry_id)
     comp_map = {(c.recurrence_index, c.instance_index): c for c in comps_list}
@@ -689,6 +700,12 @@ async def view_calendar_entry(
             "RecurrenceType": RecurrenceType,
             "entry_start": entry_start,
             "entry_end": entry_end,
+            "prev_entry": prev_entry,
+            "next_entry": next_entry,
+            "prev_start": prev_start,
+            "prev_end": prev_end,
+            "next_start": next_start,
+            "next_end": next_end,
         },
     )
 

--- a/choretracker/calendar.py
+++ b/choretracker/calendar.py
@@ -55,6 +55,12 @@ class CalendarEntry(SQLModel, table=True):
     none_before: Optional[datetime] = None
     responsible: List[str] = Field(default_factory=list, sa_column=Column(JSON))
     managers: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    previous_entry: Optional[int] = Field(
+        default=None, foreign_key="calendarentry.id"
+    )
+    next_entry: Optional[int] = Field(
+        default=None, foreign_key="calendarentry.id"
+    )
 
     @property
     def duration(self) -> timedelta:
@@ -186,6 +192,12 @@ class CalendarEntryStore:
             session.add(entry)
             session.add(new_entry)
             session.commit()
+
+            # Link entries
+            entry.next_entry = new_entry.id
+            new_entry.previous_entry = entry.id
+            session.add(entry)
+            session.add(new_entry)
 
             # Move completions
             comps = session.exec(

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -93,6 +93,7 @@ document.querySelectorAll('.checkbox-icon[data-action]').forEach(el => {
         await fetch(url, {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
+            credentials: 'same-origin',
             body: JSON.stringify({recurrence_index: r, instance_index: i})
         });
         location.reload();
@@ -112,7 +113,7 @@ document.addEventListener('DOMContentLoaded', function () {
             input.value = li.dataset.user;
             form.appendChild(input);
         });
-        fetch(form.action, { method: 'POST', body: new FormData(form) }).then(() => location.reload());
+        fetch(form.action, { method: 'POST', credentials: 'same-origin', body: new FormData(form) }).then(() => location.reload());
     }
     list.addEventListener('click', e => {
         if (e.target.closest('.remove-user')) {

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -137,6 +137,7 @@ document.querySelectorAll('.checkbox-icon[data-action="remove"]').forEach(el => 
         await fetch(`/calendar/${entry}/completion/remove`, {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
+            credentials: 'same-origin',
             body: JSON.stringify({recurrence_index: r, instance_index: i})
         });
         location.reload();
@@ -184,6 +185,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 await fetch(`/calendar/${entryId}/update`, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
+                    credentials: 'same-origin',
                     body: JSON.stringify({first_start: input.value})
                 });
                 location.reload();
@@ -234,6 +236,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 await fetch(`/calendar/${entryId}/update`, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
+                    credentials: 'same-origin',
                     body: JSON.stringify({
                         duration_days: parseInt(dayInput.value || '0'),
                         duration_hours: parseInt(hourInput.value || '0'),
@@ -271,6 +274,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 await fetch(`/calendar/${entryId}/update`, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
+                    credentials: 'same-origin',
                     body: JSON.stringify({ none_after: input.value })
                 });
                 location.reload();
@@ -351,6 +355,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 await fetch(`/calendar/${entryId}/update`, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
+                    credentials: 'same-origin',
                     body: JSON.stringify({managers: managers})
                 });
                 location.reload();
@@ -431,6 +436,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 await fetch(`/calendar/${entryId}/update`, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
+                    credentials: 'same-origin',
                     body: JSON.stringify({responsible: responsible})
                 });
                 location.reload();
@@ -650,6 +656,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const resp = await fetch(`/calendar/${entryId}/update`, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
+                    credentials: 'same-origin',
                     body: JSON.stringify({description: textarea.value})
                 });
                 const data = await resp.json();
@@ -691,6 +698,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 await fetch(`/calendar/${entryId}/update`, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
+                    credentials: 'same-origin',
                     body: JSON.stringify({title: titleInput.value, type: typeSelect.value})
                 });
                 location.reload();

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -14,6 +14,12 @@
     {% endif %}
 </h1>
 <p class="time-range">{{ time_range_summary(entry_start, entry_end) }}</p>
+{% if prev_entry %}
+<p class="time-range">Previous: <a href="{{ url_for('view_calendar_entry', entry_id=prev_entry.id) }}">{{ time_range_summary(prev_start, prev_end) }}</a></p>
+{% endif %}
+{% if next_entry %}
+<p class="time-range">Next: <a href="{{ url_for('view_calendar_entry', entry_id=next_entry.id) }}">{{ time_range_summary(next_start, next_end) }}</a></p>
+{% endif %}
 <div class="description" id="description-container">
     <div id="description-text">{{ entry.description|markdown }}</div>
     {% if can_edit %}

--- a/choretracker/templates/index.html
+++ b/choretracker/templates/index.html
@@ -116,6 +116,7 @@ document.querySelectorAll('.checkbox-icon[data-action]').forEach(el => {
         await fetch(url, {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
+            credentials: 'same-origin',
             body: JSON.stringify({recurrence_index: r, instance_index: i})
         });
         location.reload();

--- a/tests/test_split_description.py
+++ b/tests/test_split_description.py
@@ -82,6 +82,28 @@ def test_description_edit_splits_entry(tmp_path, monkeypatch):
     assert {(c.recurrence_index, c.instance_index) for c in old_comps} == {(0, 0)}
     assert {(c.recurrence_index, c.instance_index) for c in new_comps} == {(0, 1)}
 
+    # new linking fields
+    assert old_entry.next_entry == new_entry.id
+    assert new_entry.previous_entry == old_entry.id
+
+    # ensure previous/next links show on pages
+    old_start, old_end = app_module.entry_time_bounds(old_entry)
+    new_start, new_end = app_module.entry_time_bounds(new_entry)
+
+    page_old = client.get(f"/calendar/entry/{old_entry.id}")
+    next_summary = app_module.time_range_summary(new_start, new_end)
+    assert (
+        f'Next: <a href="http://testserver/calendar/entry/{new_entry.id}">{next_summary}</a>'
+        in page_old.text
+    )
+
+    page_new = client.get(f"/calendar/entry/{new_entry.id}")
+    prev_summary = app_module.time_range_summary(old_start, old_end)
+    assert (
+        f'Previous: <a href="http://testserver/calendar/entry/{old_entry.id}">{prev_summary}</a>'
+        in page_new.text
+    )
+
     page = client.get(f"/calendar/entry/{new_entry.id}")
     expected_nb = fake_now.strftime("%A %Y-%m-%d %H:%M")
     assert (


### PR DESCRIPTION
## Summary
- add optional `previous_entry` and `next_entry` references on `CalendarEntry`
- populate these fields when splitting an entry
- surface links to adjacent entries on calendar entry view page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad3c3e6e70832cb4700e27571001f1