### PR TITLE
Hide add recurrence button when a new recurrence is pending

### DIFF
--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -449,6 +449,9 @@ document.addEventListener('DOMContentLoaded', () => {
     let recList = document.getElementById('recurrence-list');
 
     function setupRecurrenceEditor(li, rindex, originalType, originalResp, offsetSeconds, isNew) {
+        if (isNew && addRecurrence) {
+            addRecurrence.style.display = 'none';
+        }
         const days = Math.floor(offsetSeconds / 86400);
         const hours = Math.floor((offsetSeconds % 86400) / 3600);
         const minutes = Math.floor((offsetSeconds % 3600) / 60);
@@ -586,6 +589,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 li.remove();
                 if (!recList || recList.children.length === 0) {
                     recContainer.textContent = 'None';
+                }
+                if (addRecurrence) {
+                    addRecurrence.style.display = '';
                 }
             } else {
                 location.reload();


### PR DESCRIPTION
## Summary
- Hide the "Add recurrence" button on the CalendarEntry view while a new recurrence editor is open
- Restore the button when the pending recurrence is cancelled

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad47126ac8832c959fc59d99ab5226