### PR TITLE
Split calendar entries on edits to past instances

### DIFF
--- a/tests/test_inline_edit.py
+++ b/tests/test_inline_edit.py
@@ -33,13 +33,22 @@ def test_inline_update(tmp_path, monkeypatch):
     entry_id = app_module.calendar_store.list_entries()[0].id
 
     # Update first_start and description
-    client.post(f"/calendar/{entry_id}/update", json={"first_start": "2000-02-01T00:00", "description": "New desc"})
+    resp = client.post(
+        f"/calendar/{entry_id}/update",
+        json={"first_start": "2000-02-01T00:00", "description": "New desc"},
+    )
+    data = resp.json()
+    if "redirect" in data:
+        entry_id = int(data["redirect"].split("/")[-1])
     page = client.get(f"/calendar/entry/{entry_id}")
     assert "2000-02-01 00:00" in page.text
     assert "New desc" in page.text
 
     # Update title and type
-    client.post(f"/calendar/{entry_id}/update", json={"title": "New Title", "type": "Reminder"})
+    client.post(
+        f"/calendar/{entry_id}/update",
+        json={"title": "New Title", "type": "Reminder"},
+    )
     page = client.get(f"/calendar/entry/{entry_id}")
     assert "New Title" in page.text
     assert "Reminder" in page.text

--- a/tests/test_recurrence_add_delete.py
+++ b/tests/test_recurrence_add_delete.py
@@ -51,8 +51,12 @@ def test_add_recurrence(tmp_path, monkeypatch):
         },
     )
     assert resp.status_code == 200
+    data = resp.json()
+    new_id = entry_id
+    if "redirect" in data:
+        new_id = int(data["redirect"].split("/")[-1])
 
-    updated = app_module.calendar_store.get(entry_id)
+    updated = app_module.calendar_store.get(new_id)
     assert len(updated.recurrences) == 1
     rec = updated.recurrences[0]
     assert rec.type == RecurrenceType.Weekly
@@ -83,11 +87,17 @@ def test_delete_recurrence(tmp_path, monkeypatch):
         json={"recurrence_index": 0},
     )
     assert resp.status_code == 200
+    data = resp.json()
+    new_id = entry_id
+    if "redirect" in data:
+        new_id = int(data["redirect"].split("/")[-1])
 
-    updated = app_module.calendar_store.get(entry_id)
+    updated = app_module.calendar_store.get(new_id)
     assert len(updated.recurrences) == 1
     assert updated.recurrences[0].type == RecurrenceType.MonthlyDayOfMonth
 
-    comps = app_module.completion_store.list_for_entry(entry_id)
-    assert len(comps) == 1
-    assert comps[0].recurrence_index == 0
+    comps_old = app_module.completion_store.list_for_entry(entry_id)
+    assert len(comps_old) == 1
+    assert comps_old[0].recurrence_index == 1
+    comps_new = app_module.completion_store.list_for_entry(new_id)
+    assert comps_new == []

--- a/tests/test_recurrence_update.py
+++ b/tests/test_recurrence_update.py
@@ -62,6 +62,9 @@ def test_update_recurrence_responsible_and_offset(tmp_path, monkeypatch):
         },
     )
     assert resp.status_code == 200
+    data = resp.json()
+    if "redirect" in data:
+        entry_id = int(data["redirect"].split("/")[-1])
 
     updated = app_module.calendar_store.get(entry_id)
     rec = updated.recurrences[0]


### PR DESCRIPTION
## Summary
- split entries with past instances when editing title, type, first_start, duration, or recurrences
- apply field changes to new entry and redirect after split
- adjust tests to cover new splitting behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad4b84f578832cbdbfcb3fc30e1575