### PR TITLE
Improve validation for usernames and calendar entries

### DIFF
--- a/choretracker/templates/calendar/form.html
+++ b/choretracker/templates/calendar/form.html
@@ -406,6 +406,12 @@ document.addEventListener('DOMContentLoaded', () => {
             alert('At least one manager required');
             return;
         }
+        const entryType = document.querySelector('input[name="type"]').value;
+        if (entryType === 'Chore' && entryRespManager.list.querySelectorAll('li').length === 0) {
+            e.preventDefault();
+            alert('At least one responsible user required');
+            return;
+        }
     });
 });
 </script>

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -269,7 +269,15 @@ document.addEventListener('DOMContentLoaded', () => {
             label.textContent = 'Never after: ';
             const input = document.createElement('input');
             input.type = 'datetime-local';
-            if (current) input.value = current;
+            if (current) {
+                input.value = current;
+            } else {
+                const now = new Date();
+                const local = new Date(now.getTime() - now.getTimezoneOffset() * 60000)
+                    .toISOString()
+                    .slice(0, 16);
+                input.value = local;
+            }
             input.className = 'inline-input';
             const clearBtn = makeBtn(trashUrl, 'Clear');
             const save = makeBtn(diskUrl, 'Save');

--- a/choretracker/templates/login.html
+++ b/choretracker/templates/login.html
@@ -13,7 +13,7 @@
             <div class="field">
                 <label>
                     <span>Username</span>
-                    <input type="text" name="username">
+                    <input type="text" name="username" pattern="[A-Za-z0-9._~-]+" title="Username must be URL-safe">
                 </label>
             </div>
             <div class="field">

--- a/choretracker/templates/users/form.html
+++ b/choretracker/templates/users/form.html
@@ -14,7 +14,7 @@
     <div class="field">
         <label>
             <span>Username</span>
-            <input type="text" name="username" value="{{ user.username if user else '' }}">
+            <input type="text" name="username" value="{{ user.username if user else '' }}" pattern="[A-Za-z0-9._~-]+" title="Username must be URL-safe">
         </label>
     </div>
     <div class="field">

--- a/choretracker/templates/users/list.html
+++ b/choretracker/templates/users/list.html
@@ -10,9 +10,11 @@
         <img src="{{ url_for('profile_picture', username=u.username) }}" alt="{{ u.username }}" class="profile-icon">
         {{ u.username }}{% if 'admin' in u.permissions %} (admin){% endif %}
         <a href="{{ url_for('edit_user', username=u.username) }}"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></a>
+        {% if u.username not in undeletable %}
         <form method="post" action="{{ url_for('delete_user', username=u.username) }}" style="display:inline">
             <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
         </form>
+        {% endif %}
     </li>
 {% endfor %}
 </ul>

--- a/tests/test_entry_managers.py
+++ b/tests/test_entry_managers.py
@@ -35,29 +35,28 @@ def test_edit_permissions(tmp_path, monkeypatch):
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[0].id
 
-    # Manager can edit
+    # Manager cannot edit past entries
     client.post("/login", data={"username": "Manager", "password": "manager"}, follow_redirects=False)
     resp = client.post(f"/calendar/{entry_id}/update", json={"title": "Updated"})
+    assert resp.status_code == 400
+    assert app_module.calendar_store.get(entry_id).title == "Test"
+
+    # Non-manager without admin cannot edit
+    client.post("/login", data={"username": "Bob", "password": "bob"}, follow_redirects=False)
+    resp = client.post(
+        f"/calendar/{entry_id}/update", json={"title": "Hack"}, follow_redirects=False
+    )
+    assert resp.status_code == 303
+    assert app_module.calendar_store.get(entry_id).title == "Test"
+
+    # Admin can edit even if not manager
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+    resp = client.post(f"/calendar/{entry_id}/update", json={"title": "AdminUpdate"})
     assert resp.status_code == 200
     data = resp.json()
     new_id = entry_id
     if "redirect" in data:
         new_id = int(data["redirect"].split("/")[-1])
-    assert app_module.calendar_store.get(entry_id).title == "Test"
-    assert app_module.calendar_store.get(new_id).title == "Updated"
-
-    # Non-manager without admin cannot edit
-    client.post("/login", data={"username": "Bob", "password": "bob"}, follow_redirects=False)
-    resp = client.post(
-        f"/calendar/{new_id}/update", json={"title": "Hack"}, follow_redirects=False
-    )
-    assert resp.status_code == 303
-    assert app_module.calendar_store.get(new_id).title == "Updated"
-
-    # Admin can edit even if not manager
-    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
-    resp = client.post(f"/calendar/{new_id}/update", json={"title": "AdminUpdate"})
-    assert resp.status_code == 200
     assert app_module.calendar_store.get(new_id).title == "AdminUpdate"
 
 

--- a/tests/test_non_admin_past_entry.py
+++ b/tests/test_non_admin_past_entry.py
@@ -1,0 +1,63 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_non_admin_cannot_create_or_edit_past_entries(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+
+    app_module.user_store.create("User", "user", None, {"events.write"})
+
+    client = TestClient(app_module.app)
+    client.post("/login", data={"username": "User", "password": "user"}, follow_redirects=False)
+
+    past = (datetime.now() - timedelta(days=1)).isoformat()
+    resp = client.post(
+        "/calendar/new",
+        data={
+            "title": "Past",
+            "type": "Event",
+            "first_start": past,
+            "duration_hours": "1",
+            "managers": "User",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    assert app_module.calendar_store.list_entries() == []
+
+    future = (datetime.now() + timedelta(days=1)).isoformat(timespec="minutes")
+    resp = client.post(
+        "/calendar/new",
+        data={
+            "title": "Future",
+            "type": "Event",
+            "first_start": future,
+            "duration_hours": "1",
+            "managers": "User",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    past2 = (datetime.now() - timedelta(days=2)).isoformat()
+    resp = client.post(
+        f"/calendar/{entry_id}/update",
+        json={"first_start": past2},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    assert (
+        app_module.calendar_store.get(entry_id).first_start.isoformat(timespec="minutes")
+        == future
+    )

--- a/tests/test_user_delete_restrictions.py
+++ b/tests/test_user_delete_restrictions.py
@@ -1,0 +1,42 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import CalendarEntry, CalendarEntryType
+
+
+def test_user_deletion_restricted(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+
+    app_module.user_store.create("Bob", "bob", None, set())
+    entry = CalendarEntry(
+        title="Test",
+        description="",
+        type=CalendarEntryType.Chore,
+        first_start=datetime.now() + timedelta(days=1),
+        duration_seconds=60,
+        responsible=["Bob"],
+        managers=["Bob"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+    app_module.completion_store.create(entry_id, -1, -1, "Bob")
+
+    client = TestClient(app_module.app)
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    resp = client.get("/users")
+    assert f"/users/Bob/delete" not in resp.text
+
+    resp = client.post("/users/Bob/delete", follow_redirects=False)
+    assert resp.status_code == 303
+    assert app_module.user_store.get("Bob") is not None

--- a/tests/test_username_url_safe.py
+++ b/tests/test_username_url_safe.py
@@ -1,0 +1,31 @@
+import importlib
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_url_unsafe_usernames_rejected(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+
+    client = TestClient(app_module.app)
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    resp = client.post("/users/new", data={"username": "bad/name"}, follow_redirects=False)
+    assert resp.status_code == 303
+    assert app_module.user_store.get("bad/name") is None
+
+    resp = client.post("/users/new", data={"username": "Good"}, follow_redirects=False)
+    assert resp.status_code == 303
+    assert app_module.user_store.get("Good") is not None
+
+    resp = client.post("/users/Good/edit", data={"username": "Bad Name"}, follow_redirects=False)
+    assert resp.status_code == 303
+    assert app_module.user_store.get("Good") is not None


### PR DESCRIPTION
## Summary
- validate usernames to allow only URL-safe characters
- block non-admin edits or creations that would yield past calendar instances
- prevent deleting users with calendar responsibilities or completions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae57918a5c832c90c76e2f17e86d85