### PR TITLE
Add user view page with chore summaries

### DIFF
--- a/choretracker/templates/base.html
+++ b/choretracker/templates/base.html
@@ -56,7 +56,7 @@
                 </button>
                 <div class="dropdown" id="settings-dropdown">
                     {% if current_user != 'Viewer' %}
-                    <a href="{{ url_for('edit_user', username=current_user) }}"><img src="{{ url_for('static', path='user.svg') }}" alt="Edit profile" class="icon"></a>
+                    <a href="{{ url_for('view_user', username=current_user) }}"><img src="{{ url_for('static', path='user.svg') }}" alt="View profile" class="icon"></a>
                     {% endif %}
                     {% if user_has(current_user, 'iam') %}
                     <a href="{{ url_for('list_users') }}"><img src="{{ url_for('static', path='users.svg') }}" alt="Manage users" class="icon"></a>

--- a/choretracker/templates/users/view.html
+++ b/choretracker/templates/users/view.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}{{ user.username }} - Chore Tracker{% endblock %}
+
+{% block content %}
+<h1>{{ user.username }}{% if current_user == user.username or user_has(current_user, 'iam') %}<a href="{{ url_for('edit_user', username=user.username) }}" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></a>{% endif %}</h1>
+
+<h2>Completions</h2>
+<ul>
+    {% for entry, comp in completions %}
+    <li><a href="{{ url_for('view_time_period', entry_id=comp.entry_id, rindex=comp.recurrence_index, iindex=comp.instance_index) }}">{{ entry.title }} {{ comp.completed_at|format_datetime(True) }}</a></li>
+    {% else %}
+    <li>No completions found.</li>
+    {% endfor %}
+</ul>
+
+<h2>Responsible</h2>
+<ul>
+    {% for entry in responsible_entries %}
+    <li><a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a></li>
+    {% else %}
+    <li>No calendar entries.</li>
+    {% endfor %}
+</ul>
+
+<h2>Manages</h2>
+<ul>
+    {% for entry in managed_entries %}
+    <li><a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a></li>
+    {% else %}
+    <li>No calendar entries.</li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/tests/test_view_user_page.py
+++ b/tests/test_view_user_page.py
@@ -1,0 +1,76 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+# Ensure project root is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import CalendarEntry, CalendarEntryType, Recurrence, RecurrenceType
+
+
+def test_view_user_page(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+
+    # create user Bob
+    app_module.user_store.create("Bob", "bob", None, set())
+
+    now = datetime.now()
+
+    # entry where Bob responsible and completion
+    entry1 = CalendarEntry(
+        title="Dishes",
+        description="",
+        type=CalendarEntryType.Chore,
+        first_start=now - timedelta(days=1),
+        duration_seconds=60,
+        responsible=["Bob"],
+        managers=["Admin"],
+    )
+    app_module.calendar_store.create(entry1)
+    entry1_id = app_module.calendar_store.list_entries()[0].id
+    app_module.completion_store.create(entry1_id, -1, -1, "Bob", completed_at=now)
+
+    # entry where Bob responsible via recurrence
+    entry2 = CalendarEntry(
+        title="Laundry",
+        description="",
+        type=CalendarEntryType.Chore,
+        first_start=now,
+        duration_seconds=60,
+        recurrences=[Recurrence(type=RecurrenceType.Weekly, responsible=["Bob"])],
+        managers=["Admin"],
+    )
+    app_module.calendar_store.create(entry2)
+
+    # entry managed by Bob
+    entry3 = CalendarEntry(
+        title="Managed",
+        description="",
+        type=CalendarEntryType.Event,
+        first_start=now,
+        duration_seconds=60,
+        managers=["Bob"],
+    )
+    app_module.calendar_store.create(entry3)
+
+    client = TestClient(app_module.app)
+    client.post("/login", data={"username": "Bob", "password": "bob"}, follow_redirects=False)
+
+    resp = client.get("/")
+    assert "/users/Bob" in resp.text
+    assert "/users/Bob/edit" not in resp.text
+
+    resp = client.get("/users/Bob")
+    assert "Completions" in resp.text
+    assert "Dishes" in resp.text
+    assert "Responsible" in resp.text
+    assert "Laundry" in resp.text
+    assert "Manages" in resp.text
+    assert "Managed" in resp.text


### PR DESCRIPTION
## Summary
- Add user view page listing completions, responsibilities, and managed entries
- Link gear menu to new view page and allow editing via pen icon
- Cover new view page with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae5caed928832c92b83b737eb1dd6e