### PR TITLE
Prevent profile picture caching and show pending upload indicator

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -485,12 +485,13 @@ async def logout(request: Request):
 
 @app.get("/users/{username}/profile_picture")
 async def profile_picture(username: str):
+    headers = {"Cache-Control": "no-cache, no-store, max-age=0"}
     user = user_store.get(username)
     if user and user.profile_picture:
-        return Response(user.profile_picture, media_type="image/png")
+        return Response(user.profile_picture, media_type="image/png", headers=headers)
     if username == "Viewer":
-        return FileResponse(BASE_PATH / "static" / "viewer_profile.png")
-    return FileResponse(BASE_PATH / "static" / "default_profile.png")
+        return FileResponse(BASE_PATH / "static" / "viewer_profile.png", headers=headers)
+    return FileResponse(BASE_PATH / "static" / "default_profile.png", headers=headers)
 
 
 @app.get("/calendar/new/{entry_type}", response_class=HTMLResponse)

--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -229,6 +229,19 @@ h1 .icon {
     border-radius: 50%;
 }
 
+.profile-picture .pending {
+    width: 4rem;
+    height: 4rem;
+    border-radius: 50%;
+    background-color: #ddd;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-size: 0.75rem;
+    color: #555;
+}
+
 .group .group {
     margin-left: 1rem;
 }

--- a/choretracker/templates/users/form.html
+++ b/choretracker/templates/users/form.html
@@ -122,4 +122,17 @@
     {% endif %}
     <button type="submit">Save</button>
 </form>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const input = document.getElementById('profile_picture');
+    const label = document.querySelector('label.profile-picture');
+    if (input && label) {
+        input.addEventListener('change', function () {
+            if (input.files && input.files.length > 0) {
+                label.innerHTML = '<div class="pending">Will upload on save</div>';
+            }
+        });
+    }
+});
+</script>
 {% endblock %}

--- a/tests/test_profile_picture_cache_control.py
+++ b/tests/test_profile_picture_cache_control.py
@@ -1,0 +1,26 @@
+import importlib
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_profile_picture_not_cached(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+
+    img_path = app_module.BASE_PATH / "static" / "default_profile.png"
+    img_bytes = app_module.process_profile_picture(img_path.read_bytes())
+    app_module.user_store.create("Bob", "bob", None, set(), profile_picture=img_bytes)
+
+    client = TestClient(app_module.app)
+    client.post("/login", data={"username": "Bob", "password": "bob"}, follow_redirects=False)
+    resp = client.get("/users/Bob/profile_picture")
+    assert "no-store" in resp.headers.get("cache-control", "")
+


### PR DESCRIPTION
## Summary
- Disable browser caching for user profile pictures by adding `Cache-Control: no-cache, no-store, max-age=0` headers
- Show a "Will upload on save" indicator after a new profile picture file is chosen
- Add test ensuring profile picture responses are not cached

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae6662ce70832cb848b1988af256d9