### PR TITLE
Allow delegating or skipping first calendar instance

### DIFF
--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -29,7 +29,7 @@
     {% endif %}
 </div>
 <div class="description">{{ entry.description|markdown }}</div>
-{% if can_edit and period.recurrence_index >= 0 %}
+{% if can_edit %}
 <form method="post" action="{{ request.url_for(is_skipped and 'unskip_instance' or 'skip_instance', entry_id=entry.id) }}">
     <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
     <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />

--- a/migrations/versions/9b77df98c5a2_add_first_instance_fields.py
+++ b/migrations/versions/9b77df98c5a2_add_first_instance_fields.py
@@ -1,0 +1,25 @@
+"""add first instance delegation and skip fields
+
+Revision ID: 9b77df98c5a2
+Revises: 281a93177d8a
+Create Date: 2025-09-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '9b77df98c5a2'
+down_revision: Union[str, Sequence[str], None] = '281a93177d8a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('calendarentry', sa.Column('first_instance_delegates', sa.JSON(), nullable=True))
+    op.add_column('calendarentry', sa.Column('skip_first_instance', sa.Boolean(), nullable=False, server_default='0'))
+
+
+def downgrade() -> None:
+    op.drop_column('calendarentry', 'skip_first_instance')
+    op.drop_column('calendarentry', 'first_instance_delegates')

--- a/tests/test_entry_delete_restrictions.py
+++ b/tests/test_entry_delete_restrictions.py
@@ -68,6 +68,28 @@ def test_entry_not_deleted_with_delegation(tmp_path, monkeypatch):
     assert app_module.calendar_store.get(entry_id) is not None
 
 
+def test_entry_not_deleted_with_first_instance_delegation(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+    now = datetime.now()
+    entry = CalendarEntry(
+        title="DelegatedFirst",
+        description="",
+        type=CalendarEntryType.Chore,
+        first_start=now,
+        duration_seconds=60,
+        first_instance_delegates=["Admin"],
+        managers=["Admin"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+    assert not app_module.calendar_store.delete(entry_id)
+    assert app_module.calendar_store.get(entry_id) is not None
+
+
 def test_list_hides_delete_for_undeletable(tmp_path, monkeypatch):
     db_file = tmp_path / "test.db"
     monkeypatch.setenv("CHORETRACKER_DB", str(db_file))

--- a/tests/test_first_instance_delegation.py
+++ b/tests/test_first_instance_delegation.py
@@ -1,0 +1,90 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import CalendarEntry, CalendarEntryType, Recurrence, RecurrenceType, responsible_for
+
+
+def test_delegate_first_instance(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+    client = TestClient(app_module.app)
+
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+    app_module.user_store.create("Bob", "pw", None, set())
+
+    entry = CalendarEntry(
+        title="Laundry",
+        description="",
+        type=CalendarEntryType.Chore,
+        first_start=datetime(2000, 1, 1, 8, 0, 0),
+        duration_seconds=60,
+        recurrences=[Recurrence(type=RecurrenceType.Weekly)],
+        responsible=["Admin"],
+        managers=["Admin"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    resp = client.post(
+        f"/calendar/{entry_id}/delegation",
+        data={"recurrence_index": -1, "instance_index": -1, "responsible[]": "Bob"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    entry = app_module.calendar_store.get(entry_id)
+    assert entry.first_instance_delegates == ["Bob"]
+    assert responsible_for(entry, -1, -1) == ["Bob"]
+
+    page = client.get(f"/calendar/entry/{entry_id}/period/-1/-1")
+    assert "Remove delegation" in page.text
+
+    resp = client.post(
+        f"/calendar/{entry_id}/delegation/remove",
+        data={"recurrence_index": -1, "instance_index": -1},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    entry = app_module.calendar_store.get(entry_id)
+    assert entry.first_instance_delegates == []
+    page = client.get(f"/calendar/entry/{entry_id}/period/-1/-1")
+    assert "Delegate this instance" in page.text
+
+    resp = client.post(
+        f"/calendar/{entry_id}/delegation",
+        data={"recurrence_index": -1, "instance_index": -1, "responsible[]": "Bob"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    resp = client.post(
+        f"/calendar/{entry_id}/skip",
+        data={"recurrence_index": -1, "instance_index": -1},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    entry = app_module.calendar_store.get(entry_id)
+    assert entry.first_instance_delegates == []
+    assert entry.skip_first_instance is True
+    page = client.get(f"/calendar/entry/{entry_id}/period/-1/-1")
+    assert "<h2>Delegation</h2>" not in page.text
+
+    client.post(
+        f"/calendar/{entry_id}/skip/remove",
+        data={"recurrence_index": -1, "instance_index": -1},
+        follow_redirects=False,
+    )
+    page = client.get(f"/calendar/entry/{entry_id}/period/-1/-1")
+    assert "Delegate this instance" in page.text


### PR DESCRIPTION
## Summary
- add `first_instance_delegates` and `skip_first_instance` to calendar entries
- enable delegation and skipping for the first instance via the time period view
- treat first-instance delegation/skips consistently across listings and deletion rules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae6cc24e4c832cb95506523f341ea7