### PR TITLE
Install build tools in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,20 @@ ENV UV_PROJECT_ENVIRONMENT=/app/.venv
 # Install uv
 RUN pip install --no-cache-dir uv
 
+# Install build tools required for some Python packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # Copy project metadata
 COPY pyproject.toml uv.lock ./
 
 # Install dependencies without installing the project itself
-RUN uv sync --frozen --no-install-project
+RUN uv sync --frozen --no-install-project \
+    && apt-get purge -y --auto-remove build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy application code
 COPY choretracker ./choretracker


### PR DESCRIPTION
## Summary
- Install `build-essential` in Dockerfile so packages like `httptools` compile during `uv sync`
- Remove build packages after dependency installation to keep final image smaller

## Testing
- `uv run pytest`
- `docker build -t choretracker-test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8c7a8f94832c87d12cf84cc4e1d8