### PR TITLE
Fix Alembic migrations in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,10 @@ RUN uv sync --frozen --no-install-project \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy application code and migration files
-COPY choretracker alembic.ini migrations ./
+# Copy each directory explicitly so Docker preserves their names
+COPY choretracker/ ./choretracker
+COPY alembic.ini ./alembic.ini
+COPY migrations/ ./migrations
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- preserve `migrations` directory when building the Docker image so `alembic` can locate scripts

## Testing
- `uv run alembic upgrade head`
- `uv run pytest` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68af5329e23c832ca47e3c8fe9348d99