### PR TITLE
Load session secret from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The application stores information in a SQLite database. By default, the databas
 file `choretracker.db` is created in the working directory. To use a different
 location, set the `CHORETRACKER_DB` environment variable to the desired path.
 
+The server also requires a secret key for session management. Before starting
+the application, set `CHORETRACKER_SECRET_KEY` to a secure, random value and
+keep it consistent between restarts.
+
 If no existing user has the `admin` permission, a new database is automatically
 populated with an `Admin` user (password `admin`, PIN `0000`) that has the
 `admin` permission. The `admin` permission grants all actions, including those
@@ -14,16 +18,20 @@ normally requiring `iam`.
 ### Direct execution
 
 ```bash
-CHORETRACKER_DB=/path/to/choretracker.db uv run uvicorn choretracker.app:app --host 0.0.0.0 --port 8000 --reload --reload-exclude .venv
+CHORETRACKER_DB=/path/to/choretracker.db \
+CHORETRACKER_SECRET_KEY=$(openssl rand -hex 32) \
+uv run uvicorn choretracker.app:app --host 0.0.0.0 --port 8000 --reload --reload-exclude .venv
 ```
 
 ### Docker
 
-When running in Docker, pass the environment variable and mount a volume for
+When running in Docker, pass the environment variables and mount a volume for
 the database file:
 
 ```bash
-docker run -e CHORETRACKER_DB=/data/choretracker.db -v $(pwd)/data:/data -p 8000:8000 benpelletier/choretracker
+docker run -e CHORETRACKER_DB=/data/choretracker.db \
+  -e CHORETRACKER_SECRET_KEY=$(openssl rand -hex 32) \
+  -v $(pwd)/data:/data -p 8000:8000 benpelletier/choretracker
 ```
 
 _Note that older versions of Docker may require the use of `--security-opt seccomp=unconfined` to support the `clone3` system the Tokio runtime uses._

--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -326,7 +326,10 @@ class EnsureUserMiddleware(BaseHTTPMiddleware):
 
 
 app.add_middleware(EnsureUserMiddleware)
-app.add_middleware(SessionMiddleware, secret_key="change-me")
+session_secret = os.getenv("CHORETRACKER_SECRET_KEY")
+if not session_secret:
+    raise RuntimeError("CHORETRACKER_SECRET_KEY environment variable is not set")
+app.add_middleware(SessionMiddleware, secret_key=session_secret)
 
 
 @app.get("/", response_class=HTMLResponse)


### PR DESCRIPTION
## Summary
- load session middleware secret from `CHORETRACKER_SECRET_KEY`
- document `CHORETRACKER_SECRET_KEY` in deployment instructions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af81ee3fc8832cbdf82d7eff764b28