### PR TITLE
Add CSRF protection middleware and tokens

### DIFF
--- a/choretracker/templates/base.html
+++ b/choretracker/templates/base.html
@@ -5,6 +5,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}Chore Tracker{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', path='styles.css') }}">
+    <script>
+    const CSRF_TOKEN = "{{ request.session['csrf_token'] }}";
+    const origFetch = window.fetch.bind(window);
+    window.fetch = function(url, options) {
+        options = options || {};
+        options.headers = options.headers || {};
+        if ((options.method || 'GET').toUpperCase() === 'POST') {
+            options.headers['X-CSRF-Token'] = CSRF_TOKEN;
+        }
+        return origFetch(url, options);
+    };
+    const origOpen = XMLHttpRequest.prototype.open;
+    XMLHttpRequest.prototype.open = function(method, url) {
+        this._method = method;
+        return origOpen.apply(this, arguments);
+    };
+    const origSend = XMLHttpRequest.prototype.send;
+    XMLHttpRequest.prototype.send = function(body) {
+        if ((this._method || '').toUpperCase() === 'POST') {
+            this.setRequestHeader('X-CSRF-Token', CSRF_TOKEN);
+        }
+        return origSend.apply(this, arguments);
+    };
+    </script>
 </head>
 <body>
     <nav class="navbar">

--- a/choretracker/templates/calendar/form.html
+++ b/choretracker/templates/calendar/form.html
@@ -6,6 +6,7 @@
 <h1>{% if entry %}Edit{% else %}New{% endif %} {{ entry_type }}</h1>
 <form id="entry-form" class="form" method="post" action="{% if entry %}{{ url_for('update_calendar_entry', entry_id=entry.id) }}{% else %}/calendar/new{% endif %}">
     <input type="hidden" name="type" value="{{ entry_type }}">
+    <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}">
 
     <div class="field">
         <div class="label-row">

--- a/choretracker/templates/calendar/list.html
+++ b/choretracker/templates/calendar/list.html
@@ -12,6 +12,7 @@
         <a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a>
         {% if (current_user in entry.managers or user_has(current_user, 'admin')) and can_delete[entry.id] %}
         <form method="post" action="{{ url_for('delete_calendar_entry', entry_id=entry.id) }}" style="display:inline" onsubmit="return confirm('Are you sure you want to delete this entry?');">
+            <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}">
             <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
         </form>
         {% endif %}
@@ -28,6 +29,7 @@
         <a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a>
         {% if (current_user in entry.managers or user_has(current_user, 'admin')) and can_delete[entry.id] %}
         <form method="post" action="{{ url_for('delete_calendar_entry', entry_id=entry.id) }}" style="display:inline" onsubmit="return confirm('Are you sure you want to delete this entry?');">
+            <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}">
             <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
         </form>
         {% endif %}

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -33,6 +33,7 @@
 <form method="post" action="{{ request.url_for(is_skipped and 'unskip_instance' or 'skip_instance', entry_id=entry.id) }}">
     <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
     <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+    <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
     <button type="submit" class="skip-button">{{ 'Do not skip this instance' if is_skipped else 'Skip this instance' }}</button>
 </form>
 {% if not is_skipped %}
@@ -41,6 +42,7 @@
     <form id="delegation-update-form" method="post" action="{{ request.url_for('delegate_instance', entry_id=entry.id) }}">
         <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
         <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+        <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
     </form>
     <ul class="responsible-list delegation-responsible-list" id="delegation-responsible-list">
         {% for u in delegation.responsible %}
@@ -69,6 +71,7 @@
     <form method="post" action="{{ request.url_for('remove_delegation', entry_id=entry.id) }}">
         <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
         <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+        <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
         <button type="submit" class="skip-button">Remove delegation</button>
     </form>
 {% else %}
@@ -78,6 +81,7 @@
         {% for u in responsible %}
         <input type="hidden" name="responsible[]" value="{{ u }}" />
         {% endfor %}
+        <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
         <button type="submit" class="skip-button">Delegate this instance</button>
     </form>
 {% endif %}

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -10,6 +10,7 @@
     <button type="button" id="edit-title-type" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
     {% if can_delete %}
     <form method="post" action="{{ url_for('delete_calendar_entry', entry_id=entry.id) }}" style="display:inline" onsubmit="return confirm('Are you sure you want to delete this entry?');">
+        <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}">
         <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
     </form>
     {% endif %}

--- a/choretracker/templates/login.html
+++ b/choretracker/templates/login.html
@@ -10,6 +10,7 @@
         <h1>Sign in</h1>
         {% if error %}<p class="error">{{ error }}</p>{% endif %}
         <form method="post" class="form">
+            <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}">
             <div class="field">
                 <label>
                     <span>Username</span>

--- a/choretracker/templates/users/form.html
+++ b/choretracker/templates/users/form.html
@@ -11,6 +11,7 @@
 {% block content %}
 <h1>{{ page_title }}</h1>
 <form method="post" class="form" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}">
     <div class="field">
         <label>
             <span>Username</span>

--- a/choretracker/templates/users/list.html
+++ b/choretracker/templates/users/list.html
@@ -12,6 +12,7 @@
         <a href="{{ url_for('edit_user', username=u.username) }}"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></a>
         {% if u.username not in undeletable %}
         <form method="post" action="{{ url_for('delete_user', username=u.username) }}" style="display:inline">
+            <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}">
             <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
         </form>
         {% endif %}


### PR DESCRIPTION
## Summary
- add custom CSRFMiddleware to generate and validate CSRF tokens on unsafe methods
- inject CSRF tokens into forms and auto-attach tokens to fetch/XMLHttpRequest calls

## Testing
- `CHORETRACKER_SECRET_KEY=test pytest` *(fails: Invalid CSRF token errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af9024574c832cb7e43104f9676243