### PR TITLE
Use relative URLs for proxy compatibility

### DIFF
--- a/choretracker/templates/base.html
+++ b/choretracker/templates/base.html
@@ -210,8 +210,9 @@
                 }
             });
         });
+        var switchTemplate = "{{ url_for('switch_user', username='__USER__') }}";
         function performSwitch(username, next, pin) {
-            var url = '/switch/' + encodeURIComponent(username) + '?next=' + encodeURIComponent(next);
+            var url = switchTemplate.replace('__USER__', encodeURIComponent(username)) + '?next=' + encodeURIComponent(next);
             if (window.fetch) {
                 fetch(url, {
                     method: 'POST',

--- a/choretracker/templates/calendar/form.html
+++ b/choretracker/templates/calendar/form.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <h1>{% if entry %}Edit{% else %}New{% endif %} {{ entry_type }}</h1>
-<form id="entry-form" class="form" method="post" action="{% if entry %}{{ url_for('update_calendar_entry', entry_id=entry.id) }}{% else %}/calendar/new{% endif %}">
+<form id="entry-form" class="form" method="post" action="{% if entry %}{{ url_for('update_calendar_entry', entry_id=entry.id) }}{% else %}{{ url_for('create_calendar_entry') }}{% endif %}">
     <input type="hidden" name="type" value="{{ entry_type }}">
 
     <div class="field">
@@ -102,7 +102,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const trashUrl = "{{ url_for('static', path='trash.svg') }}";
     const plusUrl = "{{ url_for('static', path='plus.svg') }}";
     const xUrl = "{{ url_for('static', path='x.svg') }}";
-    const profileUrlTemplate = "{{ request.url_for('profile_picture', username='__user__') }}";
+    const profileUrlTemplate = "{{ url_for('profile_picture', username='__user__') }}";
     const allUsers = {{ all_users()|selectattr('username','ne','Viewer')|map(attribute='username')|list|tojson }};
     const recurrenceTypes = {{ RecurrenceType|map(attribute='value')|list|tojson }};
 

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -3,11 +3,11 @@
 {% block title %}{{ entry.title }} instance - Chore Tracker{% endblock %}
 
 {% block content %}
-<h1><a href="{{ request.url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a> instance</h1>
+<h1><a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a> instance</h1>
 <div class="time-range">
     <span>{{ time_range_summary(period.start, period.end) }}</span>
     {% for user in responsible %}
-    <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
+    <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
     {% endfor %}
     {% if entry.type == CalendarEntryType.Chore %}
         {% if period.end <= now %}
@@ -30,7 +30,7 @@
 </div>
 <div class="description">{{ entry.description|markdown }}</div>
 {% if can_edit %}
-<form method="post" action="{{ request.url_for(is_skipped and 'unskip_instance' or 'skip_instance', entry_id=entry.id) }}">
+<form method="post" action="{{ url_for(is_skipped and 'unskip_instance' or 'skip_instance', entry_id=entry.id) }}">
     <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
     <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
     <button type="submit" class="skip-button">{{ 'Do not skip this instance' if is_skipped else 'Skip this instance' }}</button>
@@ -38,7 +38,7 @@
 {% if not is_skipped %}
 <h2>Delegation</h2>
 {% if delegation %}
-    <form id="delegation-update-form" method="post" action="{{ request.url_for('delegate_instance', entry_id=entry.id) }}">
+    <form id="delegation-update-form" method="post" action="{{ url_for('delegate_instance', entry_id=entry.id) }}">
         <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
         <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
     </form>
@@ -66,13 +66,13 @@
         </div>
     </div>
     {% endif %}
-    <form method="post" action="{{ request.url_for('remove_delegation', entry_id=entry.id) }}">
+    <form method="post" action="{{ url_for('remove_delegation', entry_id=entry.id) }}">
         <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
         <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
         <button type="submit" class="skip-button">Remove delegation</button>
     </form>
 {% else %}
-    <form method="post" action="{{ request.url_for('delegate_instance', entry_id=entry.id) }}">
+    <form method="post" action="{{ url_for('delegate_instance', entry_id=entry.id) }}">
         <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
         <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
         {% for u in responsible %}

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -31,7 +31,7 @@
 <dl>
     <dt>Managers: <span id="entry-managers-container" data-managers='{{ entry.managers|tojson }}'>
         {% for user in entry.managers %}
-        <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
+        <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
         {% if can_edit %}
         <button type="button" id="edit-managers" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
@@ -54,7 +54,7 @@
     </span></dt>
     <dt>Responsible: <span id="entry-responsible-container" data-responsible='{{ entry.responsible|tojson }}'>
         {% for user in entry.responsible %}
-        <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
+        <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
         {% if can_edit %}
         <button type="button" id="edit-responsible" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
@@ -68,7 +68,7 @@
             <li class="recurrence-item" data-rindex="{{ loop.index0 }}" data-type="{{ rec.type.value }}" data-offset-seconds="{{ rec.offset.exact_duration_seconds if rec.offset and rec.offset.exact_duration_seconds else 0 }}" data-responsible='{{ rec.responsible|tojson }}'>
                 <span class="recurrence-text">{{ rec.type.value }}{% if rec.offset %} (offset: {{ rec.offset|format_offset }}){% endif %}</span>
                 {% for user in rec.responsible %}
-                <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
+                <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
                 {% endfor %}
                 {% if can_edit %}
                 <button type="button" class="icon-button edit-recurrence"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
@@ -103,11 +103,11 @@
         <li>
             <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ time_range_summary(period.start, period.end) }}</a>
             {% for user in responsible %}
-            <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
+            <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
             {% endfor %}
             {% if completion %}
             <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ completion.recurrence_index }}" data-iindex="{{ completion.instance_index }}" {% if can_remove %}data-action="remove"{% endif %} />
-            <img src="{{ request.url_for('profile_picture', username=completion.completed_by) }}" alt="{{ completion.completed_by }}" class="profile-icon" />
+            <img src="{{ url_for('profile_picture', username=completion.completed_by) }}" alt="{{ completion.completed_by }}" class="profile-icon" />
             {{ completion.completed_at|format_completion_time(period.end) }}
             {% endif %}
             {% if is_skipped %} (skipped){% endif %}
@@ -122,7 +122,7 @@
         <li>
             <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ time_range_summary(period.start, period.end) }}</a>
             {% for user in responsible %}
-            <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
+            <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
             {% endfor %}
             {% if is_skipped %} (skipped){% endif %}
         </li>
@@ -153,7 +153,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const xUrl = "{{ url_for('static', path='x.svg') }}";
     const trashUrl = "{{ url_for('static', path='trash.svg') }}";
     const plusUrl = "{{ url_for('static', path='plus.svg') }}";
-    const profileUrlTemplate = "{{ request.url_for('profile_picture', username='__user__') }}";
+    const profileUrlTemplate = "{{ url_for('profile_picture', username='__user__') }}";
     const allUsers = {{ all_users()|selectattr('username','ne','Viewer')|map(attribute='username')|list|tojson }};
     const recurrenceTypes = {{ RecurrenceType|map(attribute='value')|list|tojson }};
 

--- a/choretracker/templates/index.html
+++ b/choretracker/templates/index.html
@@ -9,9 +9,9 @@
     {% for entry, period, responsible in overdue %}
     <li>
         {% for user in responsible %}
-        <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
+        <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        <a href="{{ request.url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>
         <span class="time-suffix" data-kind="due-ago" data-end="{{ period.end.timestamp() }}"></span>
         {% if user_has(request.session.get('user'), 'chores.complete_overdue') %}
         <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" data-action="add" />
@@ -27,9 +27,9 @@
     {% for entry, period, completion, responsible in now_periods %}
     <li>
         {% for user in responsible %}
-        <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
+        <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        <a href="{{ request.url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>
         {% if entry.type == CalendarEntryType.Chore %}
         {% if not completion %}
         <span class="time-suffix" data-kind="due-in" data-end="{{ period.end.timestamp() }}"></span>
@@ -51,9 +51,9 @@
     {% for entry, period, responsible in upcoming %}
     <li>
         {% for user in responsible %}
-        <img src="{{ request.url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
+        <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        <a href="{{ request.url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>
         <span class="time-suffix" data-kind="starts-in" data-start="{{ period.start.timestamp() }}"></span>
     </li>
     {% endfor %}

--- a/tests/test_calendar_entry_instances.py
+++ b/tests/test_calendar_entry_instances.py
@@ -55,23 +55,23 @@ def test_instances_past_and_upcoming(tmp_path, monkeypatch):
     assert "Past" in text and "Upcoming" in text
     # early completion should show under Past and be linked
     assert (
-        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/2">Sat 2000-01-22 00:00 to 01:00</a>' in text
+        f'<a href="./{entry_id}/period/0/2">Sat 2000-01-22 00:00 to 01:00</a>' in text
     )
     # skipped past instance is listed with annotation and responsible profile
     assert (
-        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/1">Sat 2000-01-15 00:00 to 01:00</a>' in text
+        f'<a href="./{entry_id}/period/0/1">Sat 2000-01-15 00:00 to 01:00</a>' in text
     )
     assert "(skipped)" in text
     # first upcoming instance is linked
     assert (
-        f'<a href="http://testserver/calendar/entry/{entry_id}/period/0/3">Sat 2000-01-29 00:00 to 01:00</a>' in text
+        f'<a href="./{entry_id}/period/0/3">Sat 2000-01-29 00:00 to 01:00</a>' in text
     )
     # profile icons for completed and responsible users displayed
     assert "/users/Admin/profile_picture" in text
     assert "/users/Bob/profile_picture" in text
     # Responsible icon should appear before completion details
     line = re.search(
-        rf'<a href="http://testserver/calendar/entry/{entry_id}/period/0/2">Sat 2000-01-22 00:00 to 01:00</a>(.*?)</li>',
+        rf'<a href="./{entry_id}/period/0/2">Sat 2000-01-22 00:00 to 01:00</a>(.*?)</li>',
         text,
         re.DOTALL,
     ).group(1)

--- a/tests/test_entry_delete_restrictions.py
+++ b/tests/test_entry_delete_restrictions.py
@@ -116,5 +116,5 @@ def test_list_hides_delete_for_undeletable(tmp_path, monkeypatch):
     app_module.completion_store.create(comp_id, 0, 0, "Admin")
     resp = client.get("/calendar/list/Chore")
     text = resp.text
-    assert f"/calendar/{comp_id}/delete" not in text
-    assert f"/calendar/{del_id}/delete" in text
+    assert f"../{comp_id}/delete" not in text
+    assert f"../{del_id}/delete" in text

--- a/tests/test_session_invalid_user.py
+++ b/tests/test_session_invalid_user.py
@@ -33,7 +33,7 @@ def test_deleted_user_logs_out(tmp_path, monkeypatch):
     # Access a protected endpoint; should redirect to login and clear session
     resp = client.get("/users", follow_redirects=False)
     assert resp.status_code in (303, 307)
-    assert resp.headers["location"] == "/login"
+    assert resp.headers["location"] == "./login"
 
     # Session should be cleared; login page should not redirect
     resp = client.get("/login", follow_redirects=False)

--- a/tests/test_split_description.py
+++ b/tests/test_split_description.py
@@ -65,7 +65,7 @@ def test_description_edit_splits_entry(tmp_path, monkeypatch):
     old_entry = next(e for e in entries if e.id == entry_id)
     new_entry = next(e for e in entries if e.id != entry_id)
 
-    assert data["redirect"].endswith(f"/calendar/entry/{new_entry.id}")
+    assert data["redirect"] == f"../entry/{new_entry.id}"
 
     assert old_entry.description == "Old"
     assert new_entry.description == "New"
@@ -93,14 +93,14 @@ def test_description_edit_splits_entry(tmp_path, monkeypatch):
     page_old = client.get(f"/calendar/entry/{old_entry.id}")
     next_summary = app_module.time_range_summary(new_start, new_end)
     assert (
-        f'Next: <a href="http://testserver/calendar/entry/{new_entry.id}">{next_summary}</a>'
+        f'Next: <a href="./{new_entry.id}">{next_summary}</a>'
         in page_old.text
     )
 
     page_new = client.get(f"/calendar/entry/{new_entry.id}")
     prev_summary = app_module.time_range_summary(old_start, old_end)
     assert (
-        f'Previous: <a href="http://testserver/calendar/entry/{old_entry.id}">{prev_summary}</a>'
+        f'Previous: <a href="./{old_entry.id}">{prev_summary}</a>'
         in page_new.text
     )
 

--- a/tests/test_system_page.py
+++ b/tests/test_system_page.py
@@ -34,4 +34,4 @@ def test_system_page_requires_admin(tmp_path, monkeypatch):
     client.post("/login", data={"username": "User", "password": "pw"}, follow_redirects=False)
     resp = client.get("/system", follow_redirects=False)
     assert resp.status_code == 303
-    assert resp.headers["location"].endswith("/")
+    assert resp.headers["location"] == "."


### PR DESCRIPTION
## Summary
- generate relative URLs so pages and redirects work behind a reverse proxy
- swap templates and scripts to use relative paths for static assets, forms and user switching
- update tests to expect relative paths instead of absolute URLs

## Testing
- `CHORETRACKER_SECRET_KEY=secret pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af9300141c832c9c9f9b24a5563211