### PR TITLE
Harden redirect target validation

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -493,9 +493,13 @@ def _switch_target(request: Request, next: str | None) -> str:
     if next:
         parsed = urlparse(next)
         if not parsed.scheme and not parsed.netloc:
-            target = parsed.path
-            if parsed.query:
-                target += f"?{parsed.query}"
+            path = posixpath.normpath(parsed.path)
+            if not path.startswith("//"):
+                norm_parsed = urlparse(path)
+                if not norm_parsed.scheme and not norm_parsed.netloc:
+                    target = path
+                    if parsed.query:
+                        target += f"?{parsed.query}"
     return target
 
 

--- a/tests/test_switch_target_redirect.py
+++ b/tests/test_switch_target_redirect.py
@@ -1,0 +1,51 @@
+import importlib
+import sys
+from pathlib import Path
+from starlette.requests import Request
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def _make_request(app, path: str = "/switch/foo") -> Request:
+    scope = {
+        "type": "http",
+        "path": path,
+        "root_path": "",
+        "scheme": "http",
+        "method": "GET",
+        "headers": [],
+        "query_string": b"",
+        "app": app,
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+    return Request(scope)
+
+
+def test_switch_target_allowed_disallowed(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    monkeypatch.setenv("CHORETRACKER_SECRET_KEY", "test")
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+
+    req = _make_request(app_module.app)
+    default = app_module._switch_target(req, None)
+
+    allowed = {
+        "/users": "/users",
+        "relative/path": "relative/path",
+        "/foo/../users": "/users",
+    }
+    for target, expected in allowed.items():
+        assert app_module._switch_target(req, target) == expected
+
+    disallowed = [
+        "http://evil.com",
+        "//evil.com",
+        "foo/..//http://evil.com",
+    ]
+    for target in disallowed:
+        assert app_module._switch_target(req, target) == default


### PR DESCRIPTION
## Summary
- tighten `_switch_target` to reject normalized paths with schemes, netlocs, or leading `//`
- add regression tests for allowed and disallowed redirect targets

## Testing
- `CHORETRACKER_SECRET_KEY=test pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68afe4a67ccc832cbad4f75eaf413837