### PR TITLE
Allow configurable logout duration

### DIFF
--- a/choretracker/settings.py
+++ b/choretracker/settings.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from sqlmodel import Field, Session, SQLModel
+
+
+class Setting(SQLModel, table=True):
+    key: str = Field(primary_key=True)
+    value: int
+
+
+class SettingsStore:
+    """CRUD helper for :class:`Setting` objects."""
+
+    def __init__(self, engine):
+        self.engine = engine
+
+    def get_logout_duration(self) -> int:
+        with Session(self.engine) as session:
+            setting = session.get(Setting, "logout_duration_minutes")
+            if not setting:
+                setting = Setting(key="logout_duration_minutes", value=1)
+                session.add(setting)
+                session.commit()
+            return setting.value
+
+    def set_logout_duration(self, minutes: int) -> None:
+        with Session(self.engine) as session:
+            setting = session.get(Setting, "logout_duration_minutes")
+            if setting:
+                setting.value = minutes
+            else:
+                setting = Setting(key="logout_duration_minutes", value=minutes)
+            session.add(setting)
+            session.commit()

--- a/choretracker/templates/system.html
+++ b/choretracker/templates/system.html
@@ -5,4 +5,67 @@
 {% block content %}
 <h1>choretracker</h1>
 <p>{{ version }}</p>
+<p>View-only after <span id="logout-duration-container">
+    <span id="logout-duration-text">{{ logout_minutes }}</span>
+    {% if user_has(request.session.get('user'), 'admin') %}
+    <button type="button" id="edit-logout-duration" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
+    {% endif %}
+    </span> minutes</p>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    const editBtn = document.getElementById('edit-logout-duration');
+    if (!editBtn) return;
+    const diskUrl = "{{ url_for('static', path='disk.svg') }}";
+    const xUrl = "{{ url_for('static', path='x.svg') }}";
+
+    function makeBtn(url, alt) {
+        const b = document.createElement('button');
+        b.type = 'button';
+        b.className = 'icon-button';
+        const img = document.createElement('img');
+        img.src = url;
+        img.alt = alt;
+        img.className = 'icon';
+        b.appendChild(img);
+        return b;
+    }
+
+    editBtn.addEventListener('click', () => {
+        const container = document.getElementById('logout-duration-container');
+        const input = document.createElement('input');
+        input.type = 'number';
+        input.min = '1';
+        input.max = '15';
+        input.value = '{{ logout_minutes }}';
+        input.className = 'inline-input';
+        const save = makeBtn(diskUrl, 'Save');
+        const cancel = makeBtn(xUrl, 'Cancel');
+        container.innerHTML = '';
+        container.appendChild(input);
+        container.appendChild(save);
+        container.appendChild(cancel);
+        save.addEventListener('click', async () => {
+            const minutes = parseInt(input.value, 10);
+            if (isNaN(minutes) || minutes < 1 || minutes > 15) {
+                alert('Invalid value');
+                return;
+            }
+            const resp = await fetch('/system/logout_duration', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                credentials: 'same-origin',
+                body: JSON.stringify({minutes})
+            });
+            if (resp.ok) {
+                location.reload();
+            } else {
+                alert('Invalid value');
+            }
+        });
+        cancel.addEventListener('click', () => {
+            location.reload();
+        });
+    });
+});
+</script>
 {% endblock %}

--- a/choretracker/users.py
+++ b/choretracker/users.py
@@ -239,11 +239,11 @@ def init_db(engine) -> None:
 
     db_path = Path(engine.url.database)
     first_run = not db_path.exists()
-    SQLModel.metadata.create_all(engine)
 
     cfg = Config(str(Path(__file__).resolve().parent.parent / "alembic.ini"))
     cfg.set_main_option("sqlalchemy.url", str(engine.url))
     if first_run:
+        SQLModel.metadata.create_all(engine)
         command.stamp(cfg, "head")
 
     script = ScriptDirectory.from_config(cfg)

--- a/migrations/versions/3b35b9765f2c_add_settings_table.py
+++ b/migrations/versions/3b35b9765f2c_add_settings_table.py
@@ -1,0 +1,34 @@
+"""add settings table
+
+Revision ID: 3b35b9765f2c
+Revises: 9b77df98c5a2
+Create Date: 2025-08-27 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3b35b9765f2c'
+down_revision: Union[str, Sequence[str], None] = '9b77df98c5a2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'setting',
+        sa.Column('key', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column('value', sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint('key')
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('setting')


### PR DESCRIPTION
## Summary
- store logout duration in new settings table
- allow admins to edit logout duration from system page
- reject logout duration values outside 1–15 minutes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0601e5368832ca5020e0d77ee167b