### PR TITLE
Fix calendar entry form action regression

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -121,10 +121,11 @@ def _make_relative(current_path: str, target_path: str) -> str:
     cur_dir = current_path if current_path.endswith("/") else current_path.rsplit("/", 1)[0] + "/"
     rel_path = posixpath.relpath(target_path, start=cur_dir)
     if rel_path == ".":
-        # Special case: target is the current directory/root. Return an absolute
-        # path so that callers expecting "\/" (e.g. tests checking redirect
-        # locations) continue to work.
-        return "/"
+        # ``posixpath.relpath`` collapses paths like ``/calendar/new`` relative to
+        # ``/calendar/new/Chore`` to ``.``. Returning ``/`` would incorrectly point
+        # to the site root; instead return the absolute target path so forms post
+        # to the intended endpoint.
+        return target_path
     if not rel_path.startswith("."):
         rel_path = "./" + rel_path
     return rel_path

--- a/tests/test_new_entry_form_action.py
+++ b/tests/test_new_entry_form_action.py
@@ -1,0 +1,25 @@
+import sys
+import importlib
+from pathlib import Path
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+@pytest.mark.parametrize("entry_type", ["Event", "Reminder", "Chore"])
+def test_new_entry_form_action(tmp_path, monkeypatch, entry_type):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    monkeypatch.setenv("CHORETRACKER_SECRET_KEY", "test")
+    monkeypatch.setenv("CHORETRACKER_DISABLE_CSRF", "1")
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+
+    client = TestClient(app_module.app)
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    resp = client.get(f"/calendar/new/{entry_type}")
+    assert resp.status_code == 200
+    assert 'action="/calendar/new"' in resp.text


### PR DESCRIPTION
## Summary
- ensure relative URL helper does not collapse form actions to site root
- add regression tests verifying new calendar entry forms post to `/calendar/new`

## Testing
- `CHORETRACKER_SECRET_KEY=test CHORETRACKER_DISABLE_CSRF=1 uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b085131368832c93dacb3f54d23301