### PR TITLE
Add lockfile sync test and update uv lock

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,6 +30,27 @@ These instructions describe how to set up a development environment for the Chor
       - Choose **New environment** and set the location to the project root.
       - Ensure **Python** is set to **3.13** and click **OK**. PyCharm will run `uv sync` automatically.
 
+## Adding Dependencies
+
+When adding a new package to `pyproject.toml`, regenerate the lockfile so
+`uv.lock` stays in sync:
+
+```bash
+uv lock
+```
+
+The test suite checks for lockfile synchronization and will fail if this
+command is not run.
+
+## Running Tests
+
+Run all tests with the required environment variables so the application
+initializes correctly:
+
+```bash
+CHORETRACKER_SECRET_KEY=test CHORETRACKER_DISABLE_CSRF=1 uv run pytest
+```
+
 ## Running the Development Server
 From the PyCharm terminal or a system shell, start the server with:
 ```bash

--- a/tests/test_uv_lock_synced.py
+++ b/tests/test_uv_lock_synced.py
@@ -1,0 +1,16 @@
+import subprocess
+from pathlib import Path
+
+
+def test_uv_lock_up_to_date():
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        ["uv", "lock", "--check"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "uv.lock is not in sync with pyproject.toml:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -101,6 +101,18 @@ wheels = [
 ]
 
 [[package]]
+name = "bleach"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/9a/0e33f5054c54d349ea62c277191c020c2d6ef1d65ab2cb1993f91ec846d1/bleach-6.2.0.tar.gz", hash = "sha256:123e894118b8a599fd80d3ec1a6d4cc7ce4e5882b1317a7e1ba69b56e95f991f", size = 203083, upload-time = "2024-10-29T18:30:40.477Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/55/96142937f66150805c25c4d0f31ee4132fd33497753400734f9dfdcbdc66/bleach-6.2.0-py3-none-any.whl", hash = "sha256:117d9c6097a7c3d22fd578fcd8d35ff1e125df6736f554da4e432fdd63f31e5e", size = 163406, upload-time = "2024-10-29T18:30:38.186Z" },
+]
+
+[[package]]
 name = "choretracker"
 version = "0.1.0"
 source = { virtual = "." }
@@ -108,6 +120,7 @@ dependencies = [
     { name = "alembic" },
     { name = "apscheduler" },
     { name = "bcrypt" },
+    { name = "bleach" },
     { name = "fastapi" },
     { name = "itsdangerous" },
     { name = "jinja2" },
@@ -124,6 +137,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.16.4" },
     { name = "apscheduler", specifier = ">=3.11.0" },
     { name = "bcrypt", specifier = ">=4.1" },
+    { name = "bleach", specifier = ">=6.1" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
@@ -631,6 +645,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/69/c4/088825b75489cb5b6a761a4542645718893d395d8c530b38734f19da44d2/watchfiles-1.1.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d05686b5487cfa2e2c28ff1aa370ea3e6c5accfe6435944ddea1e10d93872147", size = 452240, upload-time = "2025-06-15T19:06:26.552Z" },
     { url = "https://files.pythonhosted.org/packages/10/8c/22b074814970eeef43b7c44df98c3e9667c1f7bf5b83e0ff0201b0bd43f9/watchfiles-1.1.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d0e10e6f8f6dc5762adee7dece33b722282e1f59aa6a55da5d493a97282fedd8", size = 625607, upload-time = "2025-06-15T19:06:27.606Z" },
     { url = "https://files.pythonhosted.org/packages/32/fa/a4f5c2046385492b2273213ef815bf71a0d4c1943b784fb904e184e30201/watchfiles-1.1.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:af06c863f152005c7592df1d6a7009c836a247c9d8adb78fef8575a5a98699db", size = 623315, upload-time = "2025-06-15T19:06:29.076Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- ensure uv.lock is up to date with pyproject.toml
- add test that checks lockfile synchronization
- document how to update the lockfile and run tests

## Testing
- `CHORETRACKER_SECRET_KEY=test CHORETRACKER_DISABLE_CSRF=1 uv run pytest tests/test_uv_lock_synced.py -q`
- `CHORETRACKER_SECRET_KEY=test CHORETRACKER_DISABLE_CSRF=1 uv run pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68b08cf873b4832c97a152e9eaeece76