### PR TITLE
Add none_before field to calendar entry form

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -1100,6 +1100,8 @@ async def update_calendar_entry(request: Request, entry_id: int):
 
     none_after_str = form.get("none_after")
     none_after = datetime.fromisoformat(none_after_str) if none_after_str else None
+    none_before_str = form.get("none_before")
+    none_before = datetime.fromisoformat(none_before_str) if none_before_str else None
 
     responsible = form.getlist("responsible")
     managers = form.getlist("managers")

--- a/choretracker/templates/calendar/form.html
+++ b/choretracker/templates/calendar/form.html
@@ -34,6 +34,14 @@
 
     <div class="field">
         <div class="label-row">
+            <label for="none_before">None before</label>
+            <span class="help" data-help="No instances start before this time">?</span>
+        </div>
+        <input type="datetime-local" id="none_before" name="none_before">
+    </div>
+
+    <div class="field">
+        <div class="label-row">
             <span>Duration<span class="required">*</span></span>
             <span class="help" data-help="Length of each instance">?</span>
         </div>
@@ -362,6 +370,9 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelector('input[name="duration_days"]').value = days || '';
     document.querySelector('input[name="duration_hours"]').value = hours || '';
     document.querySelector('input[name="duration_minutes"]').value = minutes || '';
+    if (data.none_before) {
+        document.getElementById('none_before').value = data.none_before.slice(0,16);
+    }
     if (data.none_after) {
         document.getElementById('none_after').value = data.none_after.slice(0,16);
     }


### PR DESCRIPTION
## Summary
- Allow setting a `none_before` datetime in the calendar entry creation/edit form
- Populate `none_before` when editing an existing entry
- Parse `none_before` in calendar entry update handler

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b09b8616e4832cb92f9fd26a5199fe