### PR TITLE
Add per-instance additional notes with annotations

### DIFF
--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -363,6 +363,11 @@ h1 .icon {
     padding: 0.25rem 0.5rem;
 }
 
+.note-marker {
+    color: red;
+    margin-left: 0.2rem;
+}
+
 .pin-modal {
     position: fixed;
     top: 0;

--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -425,3 +425,6 @@ h1 .icon {
 h1 .icon-button {
     margin-left: 0.25rem;
 }
+h2 .icon-button {
+    margin-left: 0.25rem;
+}

--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -364,7 +364,7 @@ h1 .icon {
 }
 
 .note-marker {
-    color: red;
+    color: #b91c1c;
     margin-left: 0.2rem;
 }
 

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -146,7 +146,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (noteDisplay) noteDisplay.style.display = '';
         if (noteExists) {
             if (editNoteBtn) editNoteBtn.style.display = '';
-            if (deleteNoteForm) deleteNoteForm.style.display = '';
+            if (deleteNoteForm) deleteNoteForm.style.display = 'inline';
         } else if (addNoteBtn) {
             addNoteBtn.style.display = '';
         }

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -29,31 +29,6 @@
     {% endif %}
 </div>
 <div class="description">{{ entry.description|markdown|safe }}</div>
-{% if can_edit or note %}
-<div class="additional-notes-section">
-    <h2>Additional notes</h2>
-    {% if note %}
-    <div class="additional-notes">{{ note|markdown|safe }}</div>
-    {% endif %}
-    {% if can_edit %}
-    <form method="post" action="{{ url_for('add_instance_note', entry_id=entry.id) }}">
-        <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
-        <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
-        <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
-        <textarea name="note" rows="4" cols="40">{{ note or '' }}</textarea>
-        <button type="submit" class="skip-button">Save notes</button>
-    </form>
-    {% if note %}
-    <form method="post" action="{{ url_for('remove_instance_note', entry_id=entry.id) }}" style="display:inline">
-        <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
-        <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
-        <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
-        <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
-    </form>
-    {% endif %}
-    {% endif %}
-</div>
-{% endif %}
 {% if can_edit %}
 <form method="post" action="{{ url_for(is_skipped and 'unskip_instance' or 'skip_instance', entry_id=entry.id) }}">
     <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
@@ -61,7 +36,43 @@
     <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
     <button type="submit" class="skip-button">{{ 'Do not skip this instance' if is_skipped else 'Skip this instance' }}</button>
 </form>
-{% if not is_skipped %}
+{% endif %}
+{% if can_edit or note %}
+<div class="additional-notes-section">
+    <h2>
+        Additional notes
+        {% if note %}
+            {% if can_edit %}
+            <button type="button" id="edit-note" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
+            <form method="post" action="{{ url_for('remove_instance_note', entry_id=entry.id) }}" style="display:inline" id="delete-note-form">
+                <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
+                <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+                <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
+                <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
+            </form>
+            {% endif %}
+        {% elif can_edit %}
+            <button type="button" id="add-note" class="icon-button"><img src="{{ url_for('static', path='plus.svg') }}" alt="Add" class="icon"></button>
+        {% endif %}
+    </h2>
+    {% if note %}
+    <div id="note-display" class="additional-notes">{{ note|markdown|safe }}</div>
+    {% endif %}
+    {% if can_edit %}
+    <form method="post" action="{{ url_for('add_instance_note', entry_id=entry.id) }}" id="note-editor" style="display:none">
+        <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
+        <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+        <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
+        <textarea name="note" rows="4" cols="40">{{ note or '' }}</textarea>
+        <div>
+            <button type="submit" class="icon-button"><img src="{{ url_for('static', path='disk.svg') }}" alt="Save" class="icon"></button>
+            <button type="button" id="cancel-note" class="icon-button"><img src="{{ url_for('static', path='x.svg') }}" alt="Cancel" class="icon"></button>
+        </div>
+    </form>
+    {% endif %}
+</div>
+{% endif %}
+{% if can_edit and not is_skipped %}
 <h2>
     Delegation
     {% if delegation and can_edit %}
@@ -85,7 +96,6 @@
 {% endif %}
 {% if can_edit %}
 <div id="delegation-editor" style="display:none"></div>
-{% endif %}
 {% endif %}
 {% endif %}
 <script>
@@ -114,6 +124,33 @@ document.addEventListener('DOMContentLoaded', () => {
     const xUrl = "{{ url_for('static', path='x.svg') }}";
     const plusUrl = "{{ url_for('static', path='plus.svg') }}";
     const trashUrl = "{{ url_for('static', path='trash.svg') }}";
+    const noteExists = {{ 'true' if note else 'false' }};
+    const addNoteBtn = document.getElementById('add-note');
+    const editNoteBtn = document.getElementById('edit-note');
+    const deleteNoteForm = document.getElementById('delete-note-form');
+    const noteEditor = document.getElementById('note-editor');
+    const noteDisplay = document.getElementById('note-display');
+    const cancelNoteBtn = document.getElementById('cancel-note');
+
+    function openNoteEditor() {
+        if (noteEditor) noteEditor.style.display = 'block';
+        if (noteDisplay) noteDisplay.style.display = 'none';
+        if (addNoteBtn) addNoteBtn.style.display = 'none';
+        if (editNoteBtn) editNoteBtn.style.display = 'none';
+        if (deleteNoteForm) deleteNoteForm.style.display = 'none';
+    }
+    if (addNoteBtn) addNoteBtn.addEventListener('click', openNoteEditor);
+    if (editNoteBtn) editNoteBtn.addEventListener('click', openNoteEditor);
+    if (cancelNoteBtn) cancelNoteBtn.addEventListener('click', () => {
+        if (noteEditor) noteEditor.style.display = 'none';
+        if (noteDisplay) noteDisplay.style.display = '';
+        if (noteExists) {
+            if (editNoteBtn) editNoteBtn.style.display = '';
+            if (deleteNoteForm) deleteNoteForm.style.display = '';
+        } else if (addNoteBtn) {
+            addNoteBtn.style.display = '';
+        }
+    });
 
     function makeBtn(url, alt) {
         const b = document.createElement('button');

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -29,6 +29,31 @@
     {% endif %}
 </div>
 <div class="description">{{ entry.description|markdown|safe }}</div>
+{% if can_edit or note %}
+<div class="additional-notes-section">
+    <h2>Additional notes</h2>
+    {% if note %}
+    <div class="additional-notes">{{ note|markdown|safe }}</div>
+    {% endif %}
+    {% if can_edit %}
+    <form method="post" action="{{ url_for('add_instance_note', entry_id=entry.id) }}">
+        <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
+        <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+        <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
+        <textarea name="note" rows="4" cols="40">{{ note or '' }}</textarea>
+        <button type="submit" class="skip-button">Save notes</button>
+    </form>
+    {% if note %}
+    <form method="post" action="{{ url_for('remove_instance_note', entry_id=entry.id) }}" style="display:inline">
+        <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
+        <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+        <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
+        <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
+    </form>
+    {% endif %}
+    {% endif %}
+</div>
+{% endif %}
 {% if can_edit %}
 <form method="post" action="{{ url_for(is_skipped and 'unskip_instance' or 'skip_instance', entry_id=entry.id) }}">
     <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -100,9 +100,9 @@
     {% if past_instances %}
     <h3>Past <a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}?past_entries={{ past_entries + 5 }}&upcoming_entries={{ upcoming_entries }}" class="icon-button"><img src="{{ url_for('static', path='plus.svg') }}" alt="Show more past instances" class="icon"></a></h3>
     <ul class="time-list">
-        {% for period, completion, can_remove, is_skipped, responsible in past_instances %}
+        {% for period, completion, can_remove, is_skipped, responsible, has_note in past_instances %}
         <li>
-            <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ time_range_summary(period.start, period.end) }}</a>
+            <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ time_range_summary(period.start, period.end) }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
             {% for user in responsible %}
             <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
             {% endfor %}
@@ -119,9 +119,9 @@
     {% if upcoming_instances %}
     <h3>Upcoming <a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}?past_entries={{ past_entries }}&upcoming_entries={{ upcoming_entries + 5 }}" class="icon-button"><img src="{{ url_for('static', path='plus.svg') }}" alt="Show more upcoming instances" class="icon"></a></h3>
     <ul class="time-list">
-        {% for period, completion, can_remove, is_skipped, responsible in upcoming_instances %}
+        {% for period, completion, can_remove, is_skipped, responsible, has_note in upcoming_instances %}
         <li>
-            <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ time_range_summary(period.start, period.end) }}</a>
+            <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ time_range_summary(period.start, period.end) }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
             {% for user in responsible %}
             <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
             {% endfor %}

--- a/choretracker/templates/index.html
+++ b/choretracker/templates/index.html
@@ -6,12 +6,12 @@
 {% if overdue %}
 <h2>Overdue</h2>
 <ul class="time-list">
-    {% for entry, period, responsible in overdue %}
+    {% for entry, period, responsible, has_note in overdue %}
     <li>
         {% for user in responsible %}
         <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
         <span class="time-suffix" data-kind="due-ago" data-end="{{ period.end.timestamp() }}"></span>
         {% if user_has(request.session.get('user'), 'chores.complete_overdue') %}
         <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" data-action="add" />
@@ -24,12 +24,12 @@
 {% if now_periods %}
 <h2>Now</h2>
 <ul class="time-list">
-    {% for entry, period, completion, responsible in now_periods %}
+    {% for entry, period, completion, responsible, has_note in now_periods %}
     <li>
         {% for user in responsible %}
         <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
         {% if entry.type == CalendarEntryType.Chore %}
         {% if not completion %}
         <span class="time-suffix" data-kind="due-in" data-end="{{ period.end.timestamp() }}"></span>
@@ -48,12 +48,12 @@
 {% if upcoming %}
 <h2>Upcoming</h2>
 <ul class="time-list">
-    {% for entry, period, responsible in upcoming %}
+    {% for entry, period, responsible, has_note in upcoming %}
     <li>
         {% for user in responsible %}
         <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
         <span class="time-suffix" data-kind="starts-in" data-start="{{ period.start.timestamp() }}"></span>
     </li>
     {% endfor %}

--- a/choretracker/templates/users/view.html
+++ b/choretracker/templates/users/view.html
@@ -7,8 +7,8 @@
 
 <h2>Completions</h2>
 <ul>
-    {% for entry, comp in completions %}
-    <li><a href="{{ url_for('view_time_period', entry_id=comp.entry_id, rindex=comp.recurrence_index, iindex=comp.instance_index) }}">{{ entry.title }} {{ comp.completed_at|format_datetime(True) }}</a></li>
+    {% for entry, comp, has_note in completions %}
+    <li><a href="{{ url_for('view_time_period', entry_id=comp.entry_id, rindex=comp.recurrence_index, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %} {{ comp.completed_at|format_datetime(True) }}</a></li>
     {% else %}
     <li>No completions found.</li>
     {% endfor %}

--- a/migrations/versions/5c1b88f8f2c0_add_instance_notes.py
+++ b/migrations/versions/5c1b88f8f2c0_add_instance_notes.py
@@ -1,0 +1,23 @@
+"""add first instance note field
+
+Revision ID: 5c1b88f8f2c0
+Revises: 3b35b9765f2c
+Create Date: 2025-09-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '5c1b88f8f2c0'
+down_revision: Union[str, Sequence[str], None] = '3b35b9765f2c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('calendarentry', sa.Column('first_instance_note', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('calendarentry', 'first_instance_note')

--- a/tests/test_instance_notes.py
+++ b/tests/test_instance_notes.py
@@ -1,0 +1,65 @@
+import sys
+import importlib
+from pathlib import Path
+from datetime import datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+)
+
+
+def test_instance_notes(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+    client = TestClient(app_module.app)
+
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    start = datetime.now() + timedelta(minutes=5)
+    entry = CalendarEntry(
+        title="Laundry",
+        description="",
+        type=CalendarEntryType.Chore,
+        first_start=start,
+        duration_seconds=60,
+        recurrences=[Recurrence(type=RecurrenceType.Weekly)],
+        responsible=["Admin"],
+        managers=["Admin"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    resp = client.post(
+        f"/calendar/{entry_id}/note",
+        data={"recurrence_index": -1, "instance_index": -1, "note": "<script>alert(1)</script>**Bold**"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    page = client.get(f"/calendar/entry/{entry_id}/period/-1/-1")
+    assert "<script>alert(1)</script>" not in page.text
+    assert "<strong>Bold</strong>" in page.text
+
+    home = client.get("/")
+    assert '<span class="note-marker">*</span>' in home.text
+
+    resp = client.post(
+        f"/calendar/{entry_id}/note/remove",
+        data={"recurrence_index": -1, "instance_index": -1},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    home = client.get("/")
+    assert '<span class="note-marker">*</span>' not in home.text


### PR DESCRIPTION
## Summary
- allow managers to attach and edit markdown "Additional notes" for specific CalendarEntry instances
- highlight instances with notes using a red asterisk across listings
- add migration and tests for instance notes

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a485dfe8832cbe0b62c89b4930cf