### PR TITLE
Replace delegate button with header icon

### DIFF
--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -83,6 +83,8 @@
         <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
         <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
     </form>
+    {% elif can_edit %}
+    <button type="button" id="delegate-this-instance" class="icon-button"><img src="{{ url_for('static', path='plus.svg') }}" alt="Add" class="icon"></button>
     {% endif %}
 </h2>
 {% if delegation %}
@@ -91,8 +93,6 @@
     <li data-user="{{ u }}">{{ u }}</li>
     {% endfor %}
 </ul>
-{% elif can_edit %}
-<button type="button" id="delegate-this-instance" class="skip-button">Delegate this instance</button>
 {% endif %}
 {% if can_edit %}
 <div id="delegation-editor" style="display:none"></div>

--- a/tests/test_delegate_instance.py
+++ b/tests/test_delegate_instance.py
@@ -60,7 +60,7 @@ def test_delegate_instance(tmp_path, monkeypatch):
     entry = app_module.calendar_store.get(entry_id)
     assert entry.recurrences[0].delegations == []
     page = client.get(f"/calendar/entry/{entry_id}/period/0/0")
-    assert "Delegate this instance" in page.text
+    assert 'id="delegate-this-instance"' in page.text
 
     resp = client.post(
         f"/calendar/{entry_id}/delegation",
@@ -88,7 +88,7 @@ def test_delegate_instance(tmp_path, monkeypatch):
         follow_redirects=False,
     )
     page = client.get(f"/calendar/entry/{entry_id}/period/0/0")
-    assert "Delegate this instance" in page.text
+    assert 'id="delegate-this-instance"' in page.text
 
 
 def test_delegate_instance_requires_user(tmp_path, monkeypatch):

--- a/tests/test_first_instance_delegation.py
+++ b/tests/test_first_instance_delegation.py
@@ -60,7 +60,7 @@ def test_delegate_first_instance(tmp_path, monkeypatch):
     entry = app_module.calendar_store.get(entry_id)
     assert entry.first_instance_delegates == []
     page = client.get(f"/calendar/entry/{entry_id}/period/-1/-1")
-    assert "Delegate this instance" in page.text
+    assert 'id="delegate-this-instance"' in page.text
 
     resp = client.post(
         f"/calendar/{entry_id}/delegation",
@@ -89,4 +89,4 @@ def test_delegate_first_instance(tmp_path, monkeypatch):
         follow_redirects=False,
     )
     page = client.get(f"/calendar/entry/{entry_id}/period/-1/-1")
-    assert "Delegate this instance" in page.text
+    assert 'id="delegate-this-instance"' in page.text


### PR DESCRIPTION
## Summary
- Replace "Delegate this instance" button with a plus icon in the Delegation heading
- Update delegation tests to expect the new icon

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b0c702d654832ca437d9e509021fc9