### PR TITLE
Add per-instance duration override

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -1547,9 +1547,16 @@ async def set_instance_duration(request: Request, entry_id: int):
     form = await request.form()
     rindex = int(form.get("recurrence_index", -1))
     iindex = int(form.get("instance_index", -1))
-    days = int(form.get("duration_days", 0))
-    hours = int(form.get("duration_hours", 0))
-    minutes = int(form.get("duration_minutes", 0))
+
+    def to_int(value: str | None) -> int:
+        try:
+            return int(value) if value is not None and value != "" else 0
+        except ValueError:
+            return 0
+
+    days = to_int(form.get("duration_days"))
+    hours = to_int(form.get("duration_hours"))
+    minutes = to_int(form.get("duration_minutes"))
     duration = timedelta(days=days, hours=hours, minutes=minutes)
     if duration <= timedelta(0):
         raise HTTPException(status_code=400)

--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -44,6 +44,7 @@ from .calendar import (
     ChoreCompletion,
     ChoreCompletionStore,
     Delegation,
+    InstanceDuration,
     InstanceNote,
     Offset,
     Recurrence,
@@ -52,6 +53,7 @@ from .calendar import (
     enumerate_time_periods,
     find_time_period,
     find_delegation,
+    find_instance_duration,
     find_instance_note,
     responsible_for,
 )
@@ -1035,6 +1037,10 @@ async def view_time_period(
     delegation = find_delegation(entry, rindex, iindex)
     note_obj = find_instance_note(entry, rindex, iindex)
     note = note_obj.note if note_obj else None
+    dur_obj = find_instance_duration(entry, rindex, iindex)
+    dur_override = (
+        timedelta(seconds=dur_obj.duration_seconds) if dur_obj else None
+    )
     current_user = request.session.get("user")
     return templates.TemplateResponse(
         request,
@@ -1050,6 +1056,7 @@ async def view_time_period(
             "responsible": responsible_for(entry, rindex, iindex),
             "delegation": delegation,
             "note": note,
+            "duration_override": dur_override,
         },
     )
 
@@ -1512,6 +1519,97 @@ async def remove_delegation(request: Request, entry_id: int):
                 rec.delegations[idx] = d
             if d.instance_index == iindex:
                 del rec.delegations[idx]
+                break
+        calendar_store.update(entry_id, entry)
+    else:
+        raise HTTPException(status_code=400)
+    referer = request.headers.get(
+        "referer",
+        str(
+            relative_url_for(
+                request,
+                "view_time_period",
+                entry_id=entry_id,
+                rindex=rindex,
+                iindex=iindex,
+            )
+        ),
+    )
+    return RedirectResponse(url=referer, status_code=303)
+
+
+@app.post("/calendar/{entry_id}/duration")
+async def set_instance_duration(request: Request, entry_id: int):
+    entry = calendar_store.get(entry_id)
+    if not entry:
+        raise HTTPException(status_code=404)
+    require_entry_write_permission(request, entry)
+    form = await request.form()
+    rindex = int(form.get("recurrence_index", -1))
+    iindex = int(form.get("instance_index", -1))
+    days = int(form.get("duration_days", 0))
+    hours = int(form.get("duration_hours", 0))
+    minutes = int(form.get("duration_minutes", 0))
+    duration = timedelta(days=days, hours=hours, minutes=minutes)
+    if duration <= timedelta(0):
+        raise HTTPException(status_code=400)
+    seconds = int(duration.total_seconds())
+    if rindex == -1 and iindex == -1:
+        entry.first_instance_duration_seconds = seconds
+        calendar_store.update(entry_id, entry)
+    elif 0 <= rindex < len(entry.recurrences):
+        rec = entry.recurrences[rindex]
+        if not isinstance(rec, Recurrence):
+            rec = Recurrence.model_validate(rec)
+            entry.recurrences[rindex] = rec
+        existing = find_instance_duration(entry, rindex, iindex)
+        if existing:
+            existing.duration_seconds = seconds
+        else:
+            rec.duration_overrides.append(
+                InstanceDuration(instance_index=iindex, duration_seconds=seconds)
+            )
+        calendar_store.update(entry_id, entry)
+    else:
+        raise HTTPException(status_code=400)
+    referer = request.headers.get(
+        "referer",
+        str(
+            relative_url_for(
+                request,
+                "view_time_period",
+                entry_id=entry_id,
+                rindex=rindex,
+                iindex=iindex,
+            )
+        ),
+    )
+    return RedirectResponse(url=referer, status_code=303)
+
+
+@app.post("/calendar/{entry_id}/duration/remove")
+async def remove_instance_duration(request: Request, entry_id: int):
+    entry = calendar_store.get(entry_id)
+    if not entry:
+        raise HTTPException(status_code=404)
+    require_entry_write_permission(request, entry)
+    form = await request.form()
+    rindex = int(form.get("recurrence_index", -1))
+    iindex = int(form.get("instance_index", -1))
+    if rindex == -1 and iindex == -1:
+        entry.first_instance_duration_seconds = None
+        calendar_store.update(entry_id, entry)
+    elif 0 <= rindex < len(entry.recurrences):
+        rec = entry.recurrences[rindex]
+        if not isinstance(rec, Recurrence):
+            rec = Recurrence.model_validate(rec)
+            entry.recurrences[rindex] = rec
+        for idx, d in enumerate(rec.duration_overrides):
+            if not isinstance(d, InstanceDuration):
+                d = InstanceDuration.model_validate(d)
+                rec.duration_overrides[idx] = d
+            if d.instance_index == iindex:
+                del rec.duration_overrides[idx]
                 break
         calendar_store.update(entry_id, entry)
     else:

--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -268,6 +268,10 @@ h1 .icon {
     flex-wrap: wrap;
 }
 
+.duration-display {
+    font-size: inherit;
+}
+
 .offset-inputs {
     display: flex;
     flex-direction: column;

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -54,16 +54,16 @@
         {% endif %}
     </h2>
     {% if duration_override %}
-    <div id="duration-display" data-duration-seconds="{{ duration_override.total_seconds()|int }}">{{ duration_override|format_duration }}</div>
+    <div id="duration-display" class="duration-display" data-duration-seconds="{{ duration_override.total_seconds()|int }}">{{ duration_override|format_duration }}</div>
     {% endif %}
     <form method="post" action="{{ url_for('set_instance_duration', entry_id=entry.id) }}" id="duration-editor" style="display:none">
         <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
         <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
         <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
         <div class="duration-inputs">
-            <input type="number" name="duration_days" placeholder="Days" min="0">
-            <input type="number" name="duration_hours" placeholder="Hours" min="0">
-            <input type="number" name="duration_minutes" placeholder="Minutes" min="0" max="59">
+            <input type="number" class="inline-input" name="duration_days" placeholder="Days" min="0">
+            <input type="number" class="inline-input" name="duration_hours" placeholder="Hours" min="0">
+            <input type="number" class="inline-input" name="duration_minutes" placeholder="Minutes" min="0" max="59">
         </div>
         <div>
             <button type="submit" class="icon-button"><img src="{{ url_for('static', path='disk.svg') }}" alt="Save" class="icon"></button>

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -37,6 +37,41 @@
     <button type="submit" class="skip-button">{{ 'Do not skip this instance' if is_skipped else 'Skip this instance' }}</button>
 </form>
 {% endif %}
+{% if can_edit %}
+<div class="duration-section">
+    <h2>
+        Duration
+        {% if duration_override %}
+            <button type="button" id="edit-duration" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
+            <form method="post" action="{{ url_for('remove_instance_duration', entry_id=entry.id) }}" style="display:inline" id="delete-duration-form">
+                <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
+                <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+                <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
+                <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
+            </form>
+        {% else %}
+            <button type="button" id="add-duration" class="icon-button"><img src="{{ url_for('static', path='plus.svg') }}" alt="Add" class="icon"></button>
+        {% endif %}
+    </h2>
+    {% if duration_override %}
+    <div id="duration-display" data-duration-seconds="{{ duration_override.total_seconds()|int }}">{{ duration_override|format_duration }}</div>
+    {% endif %}
+    <form method="post" action="{{ url_for('set_instance_duration', entry_id=entry.id) }}" id="duration-editor" style="display:none">
+        <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
+        <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+        <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
+        <div class="duration-inputs">
+            <input type="number" name="duration_days" placeholder="Days" min="0">
+            <input type="number" name="duration_hours" placeholder="Hours" min="0">
+            <input type="number" name="duration_minutes" placeholder="Minutes" min="0" max="59">
+        </div>
+        <div>
+            <button type="submit" class="icon-button"><img src="{{ url_for('static', path='disk.svg') }}" alt="Save" class="icon"></button>
+            <button type="button" id="cancel-duration" class="icon-button"><img src="{{ url_for('static', path='x.svg') }}" alt="Cancel" class="icon"></button>
+        </div>
+    </form>
+</div>
+{% endif %}
 {% if can_edit or note %}
 <div class="additional-notes-section">
     <h2>
@@ -132,6 +167,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const noteDisplay = document.getElementById('note-display');
     const cancelNoteBtn = document.getElementById('cancel-note');
 
+    const durationExists = {{ 'true' if duration_override else 'false' }};
+    const addDurationBtn = document.getElementById('add-duration');
+    const editDurationBtn = document.getElementById('edit-duration');
+    const deleteDurationForm = document.getElementById('delete-duration-form');
+    const durationEditor = document.getElementById('duration-editor');
+    const durationDisplay = document.getElementById('duration-display');
+    const cancelDurationBtn = document.getElementById('cancel-duration');
+
     function openNoteEditor() {
         if (noteEditor) noteEditor.style.display = 'block';
         if (noteDisplay) noteDisplay.style.display = 'none';
@@ -149,6 +192,38 @@ document.addEventListener('DOMContentLoaded', () => {
             if (deleteNoteForm) deleteNoteForm.style.display = 'inline';
         } else if (addNoteBtn) {
             addNoteBtn.style.display = '';
+        }
+    });
+
+    function openDurationEditor(initial) {
+        if (durationEditor) durationEditor.style.display = 'block';
+        if (durationDisplay) durationDisplay.style.display = 'none';
+        if (addDurationBtn) addDurationBtn.style.display = 'none';
+        if (editDurationBtn) editDurationBtn.style.display = 'none';
+        if (deleteDurationForm) deleteDurationForm.style.display = 'none';
+        const dayInput = durationEditor.querySelector('input[name="duration_days"]');
+        const hourInput = durationEditor.querySelector('input[name="duration_hours"]');
+        const minuteInput = durationEditor.querySelector('input[name="duration_minutes"]');
+        const days = Math.floor(initial / 86400);
+        const hours = Math.floor((initial % 86400) / 3600);
+        const minutes = Math.floor((initial % 3600) / 60);
+        dayInput.value = days || '';
+        hourInput.value = hours || '';
+        minuteInput.value = minutes || '';
+    }
+    if (addDurationBtn) addDurationBtn.addEventListener('click', () => openDurationEditor(0));
+    if (editDurationBtn) editDurationBtn.addEventListener('click', () => {
+        const secs = parseInt(durationDisplay.dataset.durationSeconds || '0');
+        openDurationEditor(secs);
+    });
+    if (cancelDurationBtn) cancelDurationBtn.addEventListener('click', () => {
+        if (durationEditor) durationEditor.style.display = 'none';
+        if (durationDisplay) durationDisplay.style.display = '';
+        if (durationExists) {
+            if (editDurationBtn) editDurationBtn.style.display = '';
+            if (deleteDurationForm) deleteDurationForm.style.display = 'inline';
+        } else if (addDurationBtn) {
+            addDurationBtn.style.display = '';
         }
     });
 

--- a/migrations/versions/c1a5c0d5e4f4_add_instance_duration_override.py
+++ b/migrations/versions/c1a5c0d5e4f4_add_instance_duration_override.py
@@ -1,0 +1,23 @@
+"""add instance duration override
+
+Revision ID: c1a5c0d5e4f4
+Revises: 5c1b88f8f2c0
+Create Date: 2025-09-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'c1a5c0d5e4f4'
+down_revision: Union[str, Sequence[str], None] = '5c1b88f8f2c0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('calendarentry', sa.Column('first_instance_duration_seconds', sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('calendarentry', 'first_instance_duration_seconds')

--- a/tests/test_instance_duration_override.py
+++ b/tests/test_instance_duration_override.py
@@ -47,7 +47,9 @@ def test_instance_duration_override(tmp_path, monkeypatch):
         data={
             "recurrence_index": -1,
             "instance_index": -1,
+            "duration_days": "",
             "duration_hours": "2",
+            "duration_minutes": "",
         },
         follow_redirects=False,
     )

--- a/tests/test_instance_duration_override.py
+++ b/tests/test_instance_duration_override.py
@@ -1,0 +1,66 @@
+import sys
+import importlib
+from pathlib import Path
+from datetime import timedelta
+from choretracker.time_utils import get_now
+
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+    enumerate_time_periods,
+)
+
+
+def test_instance_duration_override(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+    client = TestClient(app_module.app)
+
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    start = get_now() - timedelta(minutes=30)
+    entry = CalendarEntry(
+        title="Task",
+        description="",
+        type=CalendarEntryType.Chore,
+        first_start=start,
+        duration_seconds=3600,
+        recurrences=[Recurrence(type=RecurrenceType.Weekly)],
+        responsible=["Admin"],
+        managers=["Admin"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    resp = client.post(
+        f"/calendar/{entry_id}/duration",
+        data={
+            "recurrence_index": -1,
+            "instance_index": -1,
+            "duration_hours": "2",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    page = client.get(f"/calendar/entry/{entry_id}/period/-1/-1")
+    assert "Duration" in page.text
+    assert "2:00" in page.text
+
+    entry = app_module.calendar_store.get(entry_id)
+    period = next(enumerate_time_periods(entry))
+    assert (period.end - period.start) == timedelta(hours=2)
+
+    home = client.get("/")
+    end_ts = int(period.end.timestamp())
+    assert f'data-end="{end_ts}' in home.text


### PR DESCRIPTION
## Summary
- Allow calendar entry instances to override duration and track per-instance values
- Support editing/removing instance duration overrides and display them on instance pages
- Include database migration and tests for duration overrides

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b335d15a3c832ca17d43c08fe18dfd