### PR TITLE
feat: allow specifying end time for durations

### DIFF
--- a/choretracker/static/duration.svg
+++ b/choretracker/static/duration.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M6 2h12v2c0 1.5-2 3-4 4 2 1 4 2.5 4 4v2H6v-2c0-1.5 2-3 4-4-2-1-4-2.5-4-4V2z" stroke="currentColor" fill="none" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M4 20h16" stroke="currentColor" stroke-width="2"/>
+  <path d="M4 18v4M20 18v4" stroke="currentColor" stroke-width="2"/>
+</svg>

--- a/choretracker/static/endtime.svg
+++ b/choretracker/static/endtime.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M2 2h8v2c0 1.5-1.5 3-3 4 1.5 1 3 2.5 3 4v2H2v-2c0-1.5 1.5-3 3-4-1.5-1-3-2.5-3-4V2z" stroke="currentColor" fill="none" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M12 12h4m0 0l-2-2m2 2l-2 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M20 4v16" stroke="currentColor" stroke-width="2"/>
+</svg>

--- a/choretracker/templates/calendar/form.html
+++ b/choretracker/templates/calendar/form.html
@@ -46,9 +46,15 @@
             <span class="help" data-help="Length of each instance">?</span>
         </div>
         <div class="duration-inputs">
-            <input type="number" name="duration_days" placeholder="Days" min="0">
-            <input type="number" name="duration_hours" placeholder="Hours" min="0">
-            <input type="number" name="duration_minutes" placeholder="Minutes" min="0" max="59">
+            <button type="button" id="toggle-duration-mode" class="icon-button">
+                <img id="duration-mode-icon" src="{{ url_for('static', path='endtime.svg') }}" alt="Use end time" class="icon">
+            </button>
+            <span id="duration-fields">
+                <input type="number" name="duration_days" placeholder="Days" min="0">
+                <input type="number" name="duration_hours" placeholder="Hours" min="0">
+                <input type="number" name="duration_minutes" placeholder="Minutes" min="0" max="59">
+            </span>
+            <input type="datetime-local" id="end_time" style="display:none">
         </div>
     </div>
 
@@ -397,13 +403,27 @@ document.addEventListener('DOMContentLoaded', () => {
     const entryManagersSelector = setupUserSelector('entry-managers-container', 'managers', initialManagers);
 
     const form = document.getElementById('entry-form');
-    const durationInputs = document.querySelectorAll('.duration-inputs input');
+    const durationInputs = document.querySelectorAll('#duration-fields input');
+    const endTimeInput = document.getElementById('end_time');
+    const toggleMode = document.getElementById('toggle-duration-mode');
+    const modeIcon = document.getElementById('duration-mode-icon');
+    let useEndTime = false;
+    function computeDuration() {
+        if (useEndTime) {
+            const start = new Date(document.getElementById('first_start').value);
+            const end = new Date(endTimeInput.value);
+            return (end - start) / 1000;
+        } else {
+            const days = Number(document.querySelector('input[name="duration_days"]').value) || 0;
+            const hours = Number(document.querySelector('input[name="duration_hours"]').value) || 0;
+            const minutes = Number(document.querySelector('input[name="duration_minutes"]').value) || 0;
+            return days * 86400 + hours * 3600 + minutes * 60;
+        }
+    }
     function validateDuration() {
-        const days = Number(document.querySelector('input[name="duration_days"]').value) || 0;
-        const hours = Number(document.querySelector('input[name="duration_hours"]').value) || 0;
-        const minutes = Number(document.querySelector('input[name="duration_minutes"]').value) || 0;
-        const total = days * 86400 + hours * 3600 + minutes * 60;
-        durationInputs.forEach(inp => {
+        const total = computeDuration();
+        const targets = useEndTime ? [endTimeInput] : durationInputs;
+        targets.forEach(inp => {
             if (total <= 0) {
                 inp.setCustomValidity('Duration must be greater than 0');
             } else {
@@ -412,12 +432,53 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         return total > 0;
     }
-    durationInputs.forEach(inp => inp.addEventListener('input', validateDuration));
+    function updateEndFromInputs() {
+        const start = new Date(document.getElementById('first_start').value);
+        const days = Number(document.querySelector('input[name="duration_days"]').value) || 0;
+        const hours = Number(document.querySelector('input[name="duration_hours"]').value) || 0;
+        const minutes = Number(document.querySelector('input[name="duration_minutes"]').value) || 0;
+        const end = new Date(start.getTime() + (days * 86400 + hours * 3600 + minutes * 60) * 1000);
+        const local = new Date(end.getTime() - end.getTimezoneOffset() * 60000)
+            .toISOString()
+            .slice(0, 16);
+        endTimeInput.value = local;
+    }
+    function updateInputsFromEnd() {
+        const start = new Date(document.getElementById('first_start').value);
+        const end = new Date(endTimeInput.value);
+        const diff = end - start;
+        const days = Math.floor(diff / 86400000);
+        const hours = Math.floor((diff % 86400000) / 3600000);
+        const minutes = Math.floor((diff % 3600000) / 60000);
+        document.querySelector('input[name="duration_days"]').value = days || '';
+        document.querySelector('input[name="duration_hours"]').value = hours || '';
+        document.querySelector('input[name="duration_minutes"]').value = minutes || '';
+    }
+    toggleMode.addEventListener('click', () => {
+        useEndTime = !useEndTime;
+        if (useEndTime) {
+            modeIcon.src = "{{ url_for('static', path='duration.svg') }}";
+            document.getElementById('duration-fields').style.display = 'none';
+            endTimeInput.style.display = '';
+            updateEndFromInputs();
+        } else {
+            modeIcon.src = "{{ url_for('static', path='endtime.svg') }}";
+            document.getElementById('duration-fields').style.display = '';
+            endTimeInput.style.display = 'none';
+            updateInputsFromEnd();
+        }
+        validateDuration();
+    });
+    durationInputs.forEach(inp => inp.addEventListener('input', () => { if (!useEndTime) validateDuration(); }));
+    endTimeInput.addEventListener('input', () => { if (useEndTime) validateDuration(); });
     form.addEventListener('submit', function (e) {
         if (!validateDuration()) {
             e.preventDefault();
-            durationInputs[0].reportValidity();
+            (useEndTime ? endTimeInput : durationInputs[0]).reportValidity();
             return;
+        }
+        if (useEndTime) {
+            updateInputsFromEnd();
         }
         if (entryManagersSelector.users.length === 0) {
             e.preventDefault();

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -61,9 +61,15 @@
         <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
         <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
         <div class="duration-inputs">
-            <input type="number" class="inline-input" name="duration_days" placeholder="Days" min="0">
-            <input type="number" class="inline-input" name="duration_hours" placeholder="Hours" min="0">
-            <input type="number" class="inline-input" name="duration_minutes" placeholder="Minutes" min="0" max="59">
+            <button type="button" id="toggle-duration-mode" class="icon-button">
+                <img id="duration-mode-icon" src="{{ url_for('static', path='endtime.svg') }}" alt="Use end time" class="icon">
+            </button>
+            <span id="duration-fields">
+                <input type="number" class="inline-input" name="duration_days" placeholder="Days" min="0">
+                <input type="number" class="inline-input" name="duration_hours" placeholder="Hours" min="0">
+                <input type="number" class="inline-input" name="duration_minutes" placeholder="Minutes" min="0" max="59">
+            </span>
+            <input type="datetime-local" name="end_time" id="end_time" class="inline-input" style="display:none">
         </div>
         <div>
             <button type="submit" class="icon-button"><img src="{{ url_for('static', path='disk.svg') }}" alt="Save" class="icon"></button>
@@ -159,6 +165,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const xUrl = "{{ url_for('static', path='x.svg') }}";
     const plusUrl = "{{ url_for('static', path='plus.svg') }}";
     const trashUrl = "{{ url_for('static', path='trash.svg') }}";
+    const endtimeUrl = "{{ url_for('static', path='endtime.svg') }}";
+    const durationUrl = "{{ url_for('static', path='duration.svg') }}";
     const noteExists = {{ 'true' if note else 'false' }};
     const addNoteBtn = document.getElementById('add-note');
     const editNoteBtn = document.getElementById('edit-note');
@@ -195,21 +203,69 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    if (durationEditor) {
+    const toggleMode = document.getElementById('toggle-duration-mode');
+    const modeIcon = document.getElementById('duration-mode-icon');
+    const durationFields = document.getElementById('duration-fields');
+    const endTimeInput = document.getElementById('end_time');
+    const dayInput = durationEditor.querySelector('input[name="duration_days"]');
+    const hourInput = durationEditor.querySelector('input[name="duration_hours"]');
+    const minuteInput = durationEditor.querySelector('input[name="duration_minutes"]');
+    let useEndTime = false;
+    const periodStart = new Date("{{ period.start.strftime('%Y-%m-%dT%H:%M') }}");
+
+    function updateEndFromInputs() {
+        const d = parseInt(dayInput.value || '0');
+        const h = parseInt(hourInput.value || '0');
+        const m = parseInt(minuteInput.value || '0');
+        const end = new Date(periodStart.getTime() + (d * 86400 + h * 3600 + m * 60) * 1000);
+        const local = new Date(end.getTime() - end.getTimezoneOffset() * 60000)
+            .toISOString()
+            .slice(0, 16);
+        endTimeInput.value = local;
+    }
+    function updateInputsFromEnd() {
+        const end = new Date(endTimeInput.value);
+        const diff = end - periodStart;
+        const d = Math.floor(diff / 86400000);
+        const h = Math.floor((diff % 86400000) / 3600000);
+        const m = Math.floor((diff % 3600000) / 60000);
+        dayInput.value = d || '';
+        hourInput.value = h || '';
+        minuteInput.value = m || '';
+    }
+    toggleMode.addEventListener('click', () => {
+        useEndTime = !useEndTime;
+        if (useEndTime) {
+            modeIcon.src = durationUrl;
+            durationFields.style.display = 'none';
+            endTimeInput.style.display = '';
+            updateEndFromInputs();
+        } else {
+            modeIcon.src = endtimeUrl;
+            durationFields.style.display = '';
+            endTimeInput.style.display = 'none';
+            updateInputsFromEnd();
+        }
+    });
+
     function openDurationEditor(initial) {
         if (durationEditor) durationEditor.style.display = 'block';
         if (durationDisplay) durationDisplay.style.display = 'none';
         if (addDurationBtn) addDurationBtn.style.display = 'none';
         if (editDurationBtn) editDurationBtn.style.display = 'none';
         if (deleteDurationForm) deleteDurationForm.style.display = 'none';
-        const dayInput = durationEditor.querySelector('input[name="duration_days"]');
-        const hourInput = durationEditor.querySelector('input[name="duration_hours"]');
-        const minuteInput = durationEditor.querySelector('input[name="duration_minutes"]');
         const days = Math.floor(initial / 86400);
         const hours = Math.floor((initial % 86400) / 3600);
         const minutes = Math.floor((initial % 3600) / 60);
         dayInput.value = days || '';
         hourInput.value = hours || '';
         minuteInput.value = minutes || '';
+        updateEndFromInputs();
+        useEndTime = false;
+        modeIcon.src = endtimeUrl;
+        durationFields.style.display = '';
+        endTimeInput.style.display = 'none';
     }
     if (addDurationBtn) addDurationBtn.addEventListener('click', () => openDurationEditor(0));
     if (editDurationBtn) editDurationBtn.addEventListener('click', () => {
@@ -226,6 +282,18 @@ document.addEventListener('DOMContentLoaded', () => {
             addDurationBtn.style.display = '';
         }
     });
+    durationEditor.addEventListener('submit', e => {
+        if (useEndTime) {
+            const diff = new Date(endTimeInput.value) - periodStart;
+            if (diff <= 0) {
+                e.preventDefault();
+                alert('End time must be after start time');
+                return;
+            }
+            updateInputsFromEnd();
+        }
+    });
+    }
 
     function makeBtn(url, alt) {
         const b = document.createElement('button');

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -154,6 +154,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const xUrl = "{{ url_for('static', path='x.svg') }}";
     const trashUrl = "{{ url_for('static', path='trash.svg') }}";
     const plusUrl = "{{ url_for('static', path='plus.svg') }}";
+    const endtimeUrl = "{{ url_for('static', path='endtime.svg') }}";
+    const durationUrl = "{{ url_for('static', path='duration.svg') }}";
     const profileUrlTemplate = "{{ url_for('profile_picture', username='__user__') }}";
     const allUsers = {{ all_users()|selectattr('username','ne','Viewer')|map(attribute='username')|list|tojson }};
     const recurrenceTypes = {{ RecurrenceType|map(attribute='value')|list|tojson }};
@@ -207,23 +209,18 @@ document.addEventListener('DOMContentLoaded', () => {
         durEdit.addEventListener('click', () => {
             const container = document.getElementById('duration-container');
             const total = parseInt(container.dataset.durationSeconds || '0');
-            const days = Math.floor(total / 86400);
-            const hours = Math.floor((total % 86400) / 3600);
-            const minutes = Math.floor((total % 3600) / 60);
             container.innerHTML = '';
             const dayInput = document.createElement('input');
             dayInput.type = 'number';
             dayInput.placeholder = 'Days';
             dayInput.min = '0';
             dayInput.className = 'inline-input';
-            if (days) dayInput.value = days;
             dayInput.style.width = '4ch';
             const hourInput = document.createElement('input');
             hourInput.type = 'number';
             hourInput.placeholder = 'Hours';
             hourInput.min = '0';
             hourInput.className = 'inline-input';
-            if (hours) hourInput.value = hours;
             hourInput.style.width = '4ch';
             const minuteInput = document.createElement('input');
             minuteInput.type = 'number';
@@ -231,24 +228,90 @@ document.addEventListener('DOMContentLoaded', () => {
             minuteInput.min = '0';
             minuteInput.max = '59';
             minuteInput.className = 'inline-input';
-            if (minutes) minuteInput.value = minutes;
             minuteInput.style.width = '4ch';
+            const endInput = document.createElement('input');
+            endInput.type = 'datetime-local';
+            endInput.className = 'inline-input';
+            endInput.style.display = 'none';
+            const modeBtn = makeBtn(endtimeUrl, 'Use end time');
+            const modeImg = modeBtn.querySelector('img');
             const save = makeBtn(diskUrl, 'Save');
             const cancel = makeBtn(xUrl, 'Cancel');
+            container.appendChild(modeBtn);
             container.appendChild(dayInput);
             container.appendChild(hourInput);
             container.appendChild(minuteInput);
+            container.appendChild(endInput);
             container.appendChild(save);
             container.appendChild(cancel);
+
+            const firstStart = new Date("{{ entry.first_start.strftime('%Y-%m-%dT%H:%M') }}");
+            const days = Math.floor(total / 86400);
+            const hours = Math.floor((total % 86400) / 3600);
+            const minutes = Math.floor((total % 3600) / 60);
+            if (days) dayInput.value = days;
+            if (hours) hourInput.value = hours;
+            if (minutes) minuteInput.value = minutes;
+
+            let useEndTime = false;
+            function updateEndFromInputs() {
+                const d = parseInt(dayInput.value || '0');
+                const h = parseInt(hourInput.value || '0');
+                const m = parseInt(minuteInput.value || '0');
+                const end = new Date(firstStart.getTime() + (d * 86400 + h * 3600 + m * 60) * 1000);
+                const local = new Date(end.getTime() - end.getTimezoneOffset() * 60000)
+                    .toISOString()
+                    .slice(0, 16);
+                endInput.value = local;
+            }
+            function updateInputsFromEnd() {
+                const end = new Date(endInput.value);
+                const diff = end - firstStart;
+                const d = Math.floor(diff / 86400000);
+                const h = Math.floor((diff % 86400000) / 3600000);
+                const m = Math.floor((diff % 3600000) / 60000);
+                dayInput.value = d || '';
+                hourInput.value = h || '';
+                minuteInput.value = m || '';
+            }
+            modeBtn.addEventListener('click', () => {
+                useEndTime = !useEndTime;
+                if (useEndTime) {
+                    modeImg.src = durationUrl;
+                    dayInput.style.display = 'none';
+                    hourInput.style.display = 'none';
+                    minuteInput.style.display = 'none';
+                    endInput.style.display = '';
+                    updateEndFromInputs();
+                } else {
+                    modeImg.src = endtimeUrl;
+                    endInput.style.display = 'none';
+                    dayInput.style.display = '';
+                    hourInput.style.display = '';
+                    minuteInput.style.display = '';
+                    updateInputsFromEnd();
+                }
+            });
+
             save.addEventListener('click', async () => {
+                if (useEndTime) {
+                    updateInputsFromEnd();
+                }
+                const d = parseInt(dayInput.value || '0');
+                const h = parseInt(hourInput.value || '0');
+                const m = parseInt(minuteInput.value || '0');
+                if (d * 86400 + h * 3600 + m * 60 <= 0) {
+                    alert('Duration must be greater than 0');
+                    return;
+                }
                 const resp = await fetch(`/calendar/${entryId}/update`, {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
                     credentials: 'same-origin',
                     body: JSON.stringify({
-                        duration_days: parseInt(dayInput.value || '0'),
-                        duration_hours: parseInt(hourInput.value || '0'),
-                        duration_minutes: parseInt(minuteInput.value || '0')
+                        duration_days: d,
+                        duration_hours: h,
+                        duration_minutes: m
                     })
                 });
                 const data = await resp.json();


### PR DESCRIPTION
## Summary
- allow switching duration inputs to end-time mode with new icons
- support toggling between modes when editing CalendarEntry or instance durations
- add SVG icons for duration and end time

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b34234aeb0832c87d5cfab3c4c59de