### PR TITLE
Pre-populate instance duration defaults and rename test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   test:
+    name: make test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -176,6 +176,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const cancelNoteBtn = document.getElementById('cancel-note');
 
     const durationExists = {{ 'true' if duration_override else 'false' }};
+    const defaultDurationSeconds = {{ entry.duration.total_seconds()|int }};
     const addDurationBtn = document.getElementById('add-duration');
     const editDurationBtn = document.getElementById('edit-duration');
     const deleteDurationForm = document.getElementById('delete-duration-form');
@@ -267,7 +268,7 @@ document.addEventListener('DOMContentLoaded', () => {
         durationFields.style.display = '';
         endTimeInput.style.display = 'none';
     }
-    if (addDurationBtn) addDurationBtn.addEventListener('click', () => openDurationEditor(0));
+    if (addDurationBtn) addDurationBtn.addEventListener('click', () => openDurationEditor(defaultDurationSeconds));
     if (editDurationBtn) editDurationBtn.addEventListener('click', () => {
         const secs = parseInt(durationDisplay.dataset.durationSeconds || '0');
         openDurationEditor(secs);


### PR DESCRIPTION
## Summary
- Pre-fill instance duration editor with CalendarEntry duration and correct end time when no override
- Rename CI job so GitHub shows "Run tests / make test" in workflow runs

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b34b74fdf4832cb38318026912bc33