### PR TITLE
Ensure dropdown menus stay above page content

### DIFF
--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -81,6 +81,7 @@ h1 .icon {
     right: 0;
     background-color: #ffffff;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    z-index: 1000;
 }
 
 .dropdown.show,


### PR DESCRIPTION
## Summary
- Set a high `z-index` for dropdown menus so items are always clickable

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b5cf033614832c87085142ffbcc811