### PR TITLE
Add chore completion history page with navigation link

### DIFF
--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -192,6 +192,19 @@ h1 .icon {
     padding: 0.5rem 1rem;
 }
 
+.nav-left {
+    display: flex;
+    align-items: center;
+}
+
+.nav-left .nav-item {
+    margin-right: 0.5rem;
+}
+
+.nav-left .nav-item:last-child {
+    margin-right: 0;
+}
+
 .nav-actions {
     display: flex;
     align-items: center;

--- a/choretracker/templates/base.html
+++ b/choretracker/templates/base.html
@@ -32,10 +32,15 @@
 </head>
 <body>
     <nav class="navbar">
+        {% set current_user = request.session.get('user') %}
         <a href="{{ url_for('index') }}" class="nav-item">
             <img src="{{ url_for('static', path='home.svg') }}" alt="Home" class="icon">
         </a>
-        {% set current_user = request.session.get('user') %}
+        {% if user_has(current_user, 'chores.read') %}
+        <a href="{{ url_for('list_chore_completions') }}" class="nav-item">
+            <img src="{{ url_for('static', path='checkbox-checked.svg') }}" alt="Completions" class="icon">
+        </a>
+        {% endif %}
         {% if current_user %}
         <div class="nav-actions">
             {% if user_has(current_user, 'events.read') or user_has(current_user, 'reminders.read') or user_has(current_user, 'chores.read') %}

--- a/choretracker/templates/base.html
+++ b/choretracker/templates/base.html
@@ -33,14 +33,16 @@
 <body>
     <nav class="navbar">
         {% set current_user = request.session.get('user') %}
-        <a href="{{ url_for('index') }}" class="nav-item">
-            <img src="{{ url_for('static', path='home.svg') }}" alt="Home" class="icon">
-        </a>
-        {% if user_has(current_user, 'chores.read') %}
-        <a href="{{ url_for('list_chore_completions') }}" class="nav-item">
-            <img src="{{ url_for('static', path='checkbox-checked.svg') }}" alt="Completions" class="icon">
-        </a>
-        {% endif %}
+        <div class="nav-left">
+            <a href="{{ url_for('index') }}" class="nav-item">
+                <img src="{{ url_for('static', path='home.svg') }}" alt="Home" class="icon">
+            </a>
+            {% if user_has(current_user, 'chores.read') %}
+            <a href="{{ url_for('list_chore_completions') }}" class="nav-item">
+                <img src="{{ url_for('static', path='checkbox-checked.svg') }}" alt="Completions" class="icon">
+            </a>
+            {% endif %}
+        </div>
         {% if current_user %}
         <div class="nav-actions">
             {% if user_has(current_user, 'events.read') or user_has(current_user, 'reminders.read') or user_has(current_user, 'chores.read') %}

--- a/choretracker/templates/completions/list.html
+++ b/choretracker/templates/completions/list.html
@@ -11,6 +11,7 @@
         <img src="{{ url_for('profile_picture', username=comp.completed_by) }}" alt="{{ comp.completed_by }}" class="profile-icon" />
         <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=comp.recurrence_index, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %}</a>
         {{ comp.completed_at|format_datetime(True) }}
+        <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ comp.recurrence_index }}" data-iindex="{{ comp.instance_index }}" {% if comp.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
     </li>
     {% endfor %}
 </ul>
@@ -23,6 +24,7 @@
         <img src="{{ url_for('profile_picture', username=comp.completed_by) }}" alt="{{ comp.completed_by }}" class="profile-icon" />
         <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=comp.recurrence_index, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %}</a>
         {{ comp.completed_at|format_datetime(True) }}
+        <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ comp.recurrence_index }}" data-iindex="{{ comp.instance_index }}" {% if comp.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
     </li>
     {% endfor %}
 </ul>
@@ -35,6 +37,7 @@
         <img src="{{ url_for('profile_picture', username=comp.completed_by) }}" alt="{{ comp.completed_by }}" class="profile-icon" />
         <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=comp.recurrence_index, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %}</a>
         {{ comp.completed_at|format_datetime(True) }}
+        <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ comp.recurrence_index }}" data-iindex="{{ comp.instance_index }}" {% if comp.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
     </li>
     {% endfor %}
 </ul>
@@ -42,4 +45,23 @@
 {% if not today and not yesterday and not earlier %}
 <p>No completions.</p>
 {% endif %}
+<script>
+document.querySelectorAll('.checkbox-icon[data-action]').forEach(el => {
+    el.addEventListener('click', async () => {
+        const entry = el.dataset.entry;
+        const r = parseInt(el.dataset.rindex);
+        const i = parseInt(el.dataset.iindex);
+        const url = el.dataset.action === 'add'
+            ? `/calendar/${entry}/completion`
+            : `/calendar/${entry}/completion/remove`;
+        await fetch(url, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            credentials: 'same-origin',
+            body: JSON.stringify({recurrence_index: r, instance_index: i})
+        });
+        location.reload();
+    });
+});
+</script>
 {% endblock %}

--- a/choretracker/templates/completions/list.html
+++ b/choretracker/templates/completions/list.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+
+{% block title %}Chore Completions - Chore Tracker{% endblock %}
+
+{% block content %}
+{% if today %}
+<h2>Today</h2>
+<ul class="time-list">
+    {% for entry, comp, has_note in today %}
+    <li>
+        <img src="{{ url_for('profile_picture', username=comp.completed_by) }}" alt="{{ comp.completed_by }}" class="profile-icon" />
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=comp.recurrence_index, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %}</a>
+        {{ comp.completed_at|format_datetime(True) }}
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+{% if yesterday %}
+<h2>Yesterday</h2>
+<ul class="time-list">
+    {% for entry, comp, has_note in yesterday %}
+    <li>
+        <img src="{{ url_for('profile_picture', username=comp.completed_by) }}" alt="{{ comp.completed_by }}" class="profile-icon" />
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=comp.recurrence_index, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %}</a>
+        {{ comp.completed_at|format_datetime(True) }}
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+{% if earlier %}
+<h2>Earlier</h2>
+<ul class="time-list">
+    {% for entry, comp, has_note in earlier %}
+    <li>
+        <img src="{{ url_for('profile_picture', username=comp.completed_by) }}" alt="{{ comp.completed_by }}" class="profile-icon" />
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=comp.recurrence_index, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %}</a>
+        {{ comp.completed_at|format_datetime(True) }}
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+{% if not today and not yesterday and not earlier %}
+<p>No completions.</p>
+{% endif %}
+{% endblock %}

--- a/tests/test_chore_completions_page.py
+++ b/tests/test_chore_completions_page.py
@@ -1,0 +1,72 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def _setup_app(tmp_path, monkeypatch, fake_now):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+    monkeypatch.setattr(app_module, "get_now", lambda: fake_now)
+    import choretracker.calendar as calendar_module
+    monkeypatch.setattr(calendar_module, "get_now", lambda: fake_now)
+    client = TestClient(app_module.app)
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+    return app_module, client
+
+
+def test_chore_completions_sections(tmp_path, monkeypatch):
+    fake_now = datetime(2000, 1, 3, 12, 0, tzinfo=ZoneInfo("UTC"))
+    app_module, client = _setup_app(tmp_path, monkeypatch, fake_now)
+
+    entry = app_module.CalendarEntry(
+        title="Task",
+        description="",
+        type=app_module.CalendarEntryType.Chore,
+        first_start=fake_now - timedelta(days=5),
+        duration_seconds=60,
+        managers=["Admin"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    app_module.completion_store.create(
+        entry_id, -1, -1, "Admin", completed_at=fake_now - timedelta(hours=1)
+    )
+    app_module.completion_store.create(
+        entry_id, -1, -1, "Admin", completed_at=fake_now - timedelta(days=1, hours=1)
+    )
+    app_module.completion_store.create(
+        entry_id, -1, -1, "Admin", completed_at=fake_now - timedelta(days=2)
+    )
+
+    response = client.get("/chore_completions")
+    text = response.text
+    assert "Today" in text
+    assert "Yesterday" in text
+    assert "Earlier" in text
+    t1 = app_module.format_datetime(fake_now - timedelta(hours=1), True)
+    t2 = app_module.format_datetime(fake_now - timedelta(days=1, hours=1), True)
+    t3 = app_module.format_datetime(fake_now - timedelta(days=2), True)
+    assert text.index(t1) < text.index(t2) < text.index(t3)
+
+
+def test_nav_shows_completion_icon(tmp_path, monkeypatch):
+    fake_now = datetime(2000, 1, 1, 0, 0, tzinfo=ZoneInfo("UTC"))
+    app_module, client = _setup_app(tmp_path, monkeypatch, fake_now)
+    response = client.get("/")
+    text = response.text
+    home_idx = text.index("home.svg")
+    comp_idx = text.index("checkbox-checked.svg")
+    assert home_idx < comp_idx
+    assert 'href="./chore_completions"' in text
+


### PR DESCRIPTION
## Summary
- add nav bar link to chore completion history
- implement chore completion listing with filtering and sectioning
- test completion page and nav icon

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b5da72ec18832c80a442e25bb77e04