### PR TITLE
Show chore checkboxes for all users with unauthorized flash

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -1487,7 +1487,13 @@ async def complete_chore(request: Request, entry_id: int):
         raise HTTPException(status_code=403)
     user = request.session.get("user")
     if not user_store.has_permission(user, perm):
-        raise HTTPException(status_code=403)
+        return JSONResponse(
+            {
+                "status": "forbidden",
+                "message": f"{user} isn't authorized to complete this instance",
+            },
+            status_code=403,
+        )
     if completion_store.get(entry_id, rindex, iindex):
         return {"status": "exists"}
     completion_store.create(entry_id, rindex, iindex, user)

--- a/choretracker/templates/index.html
+++ b/choretracker/templates/index.html
@@ -132,7 +132,6 @@ document.querySelectorAll('.checkbox-icon[data-action]').forEach(el => {
                 existing.remove();
             }
             content.prepend(flash);
-            flash.scrollIntoView({ behavior: 'smooth', block: 'start' });
             return;
         }
         location.reload();

--- a/choretracker/templates/index.html
+++ b/choretracker/templates/index.html
@@ -126,7 +126,13 @@ document.querySelectorAll('.checkbox-icon[data-action]').forEach(el => {
             const flash = document.createElement('div');
             flash.className = 'flash';
             flash.textContent = data.message;
-            document.body.prepend(flash);
+            const content = document.querySelector('main.content');
+            const existing = content.querySelector('.flash');
+            if (existing) {
+                existing.remove();
+            }
+            content.prepend(flash);
+            flash.scrollIntoView({ behavior: 'smooth', block: 'start' });
             return;
         }
         location.reload();

--- a/choretracker/templates/index.html
+++ b/choretracker/templates/index.html
@@ -13,7 +13,7 @@
         {% endfor %}
         <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
         <span class="time-suffix" data-kind="due-ago" data-end="{{ period.end.timestamp() }}"></span>
-        {% if user_has(request.session.get('user'), 'chores.complete_overdue') %}
+        {% if entry.type == CalendarEntryType.Chore %}
         <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" data-action="add" />
         {% endif %}
     </li>
@@ -31,12 +31,10 @@
         {% endfor %}
         <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
         {% if entry.type == CalendarEntryType.Chore %}
-        {% if not completion %}
-        <span class="time-suffix" data-kind="due-in" data-end="{{ period.end.timestamp() }}"></span>
-        {% endif %}
         {% if completion %}
         <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" {% if completion.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
-        {% elif user_has(request.session.get('user'), 'chores.complete_on_time') %}
+        {% else %}
+        <span class="time-suffix" data-kind="due-in" data-end="{{ period.end.timestamp() }}"></span>
         <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" data-action="add" />
         {% endif %}
         {% endif %}
@@ -117,12 +115,20 @@ document.querySelectorAll('.checkbox-icon[data-action]').forEach(el => {
         const url = el.dataset.action === 'add'
             ? `/calendar/${entry}/completion`
             : `/calendar/${entry}/completion/remove`;
-        await fetch(url, {
+        const resp = await fetch(url, {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             credentials: 'same-origin',
             body: JSON.stringify({recurrence_index: r, instance_index: i})
         });
+        if (resp.status === 403) {
+            const data = await resp.json();
+            const flash = document.createElement('div');
+            flash.className = 'flash';
+            flash.textContent = data.message;
+            document.body.prepend(flash);
+            return;
+        }
         location.reload();
     });
 });

--- a/tests/test_unauthorized_completion.py
+++ b/tests/test_unauthorized_completion.py
@@ -1,0 +1,53 @@
+import importlib
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import CalendarEntry, CalendarEntryType
+from choretracker.time_utils import get_now
+
+def test_unauthorized_completion_flashes_message(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+
+    # create user without completion permissions
+    app_module.user_store.create("Bob", "bob", None, set())
+
+    now = get_now()
+    entry = CalendarEntry(
+        title="Dishes",
+        description="",
+        type=CalendarEntryType.Chore,
+        first_start=now,
+        duration_seconds=60,
+        managers=["Admin"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    client = TestClient(app_module.app)
+    client.post("/login", data={"username": "Bob", "password": "bob"}, follow_redirects=False)
+
+    # home page shows empty checkbox even without permission
+    resp = client.get("/")
+    assert f'data-entry="{entry_id}"' in resp.text
+    assert "checkbox-empty.svg" in resp.text
+
+    # attempt to complete chore without permission
+    resp = client.post(
+        f"/calendar/{entry_id}/completion",
+        json={"recurrence_index": -1, "instance_index": -1},
+    )
+    assert resp.status_code == 403
+    assert (
+        resp.json()["message"]
+        == "Bob isn't authorized to complete this instance"
+    )
+


### PR DESCRIPTION
## Summary
- Always show empty checkbox for chore entries on the home page
- Return explicit JSON message when a user lacks permission to complete a chore
- Display the message client-side and add tests for unauthorized completions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b5deebee6c832c891651a0819a1292