### PR TITLE
Add OneTime recurrence type and require recurrences

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -279,7 +279,9 @@ def entry_time_bounds(entry: CalendarEntry) -> tuple[datetime, datetime | None]:
         return (entry.first_start, None)
     start = first.start
     end = first.end
-    if entry.recurrences and entry.none_after is None:
+    if entry.none_after is None and any(
+        rec.type != RecurrenceType.OneTime for rec in entry.recurrences
+    ):
         return (start, None)
     for p in periods:
         end = p.end

--- a/migrations/versions/37f3cc068d39_add_onetime_recurrence.py
+++ b/migrations/versions/37f3cc068d39_add_onetime_recurrence.py
@@ -22,8 +22,7 @@ def upgrade() -> None:
         sa.text(
             "UPDATE calendarentry SET recurrences = :value "
             "WHERE recurrences IS NULL OR recurrences = '[]'"
-        ),
-        {"value": value},
+        ).bindparams(value=value)
     )
 
 
@@ -33,6 +32,5 @@ def downgrade() -> None:
         sa.text(
             "UPDATE calendarentry SET recurrences = '[]' "
             "WHERE recurrences = :value"
-        ),
-        {"value": value},
+        ).bindparams(value=value)
     )

--- a/migrations/versions/37f3cc068d39_add_onetime_recurrence.py
+++ b/migrations/versions/37f3cc068d39_add_onetime_recurrence.py
@@ -1,0 +1,38 @@
+"""ensure calendar entries have a recurrence
+
+Revision ID: 37f3cc068d39
+Revises: c1a5c0d5e4f4
+Create Date: 2025-09-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import json
+
+revision: str = '37f3cc068d39'
+down_revision: Union[str, Sequence[str], None] = 'c1a5c0d5e4f4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    value = json.dumps([{"type": "OneTime"}])
+    op.execute(
+        sa.text(
+            "UPDATE calendarentry SET recurrences = :value "
+            "WHERE recurrences IS NULL OR recurrences = '[]'"
+        ),
+        {"value": value},
+    )
+
+
+def downgrade() -> None:
+    value = json.dumps([{"type": "OneTime"}])
+    op.execute(
+        sa.text(
+            "UPDATE calendarentry SET recurrences = '[]' "
+            "WHERE recurrences = :value"
+        ),
+        {"value": value},
+    )


### PR DESCRIPTION
## Summary
- add `OneTime` recurrence type
- ensure calendar entries always have at least one recurrence
- migrate existing entries to include a default `OneTime` recurrence

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b5f427ff48832cb94b2c07a5e43796