### PR TITLE
Add recurrence-specific start time and duration

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -1367,6 +1367,12 @@ async def update_recurrence(request: Request, entry_id: int):
         rec.offset = Offset(exact_duration_seconds=days * 86400 + hours * 3600 + minutes * 60)
     else:
         rec.offset = None
+    if "first_start" in data:
+        fs = data["first_start"]
+        rec.first_start = parse_datetime(fs) if fs else None
+    if "duration_seconds" in data:
+        ds = data["duration_seconds"]
+        rec.duration_seconds = int(ds) if ds else None
     if "responsible" in data:
         rec.responsible = list(data["responsible"])
     if not is_admin and has_past_instances(entry):
@@ -1401,7 +1407,19 @@ async def add_recurrence(request: Request, entry_id: int):
     offset = None
     if days or hours or minutes:
         offset = Offset(exact_duration_seconds=days * 86400 + hours * 3600 + minutes * 60)
-    rec = Recurrence(type=rtype, offset=offset, responsible=list(data.get("responsible") or []))
+    first_start = (
+        parse_datetime(data["first_start"]) if data.get("first_start") else None
+    )
+    duration_seconds = (
+        int(data["duration_seconds"]) if data.get("duration_seconds") else None
+    )
+    rec = Recurrence(
+        type=rtype,
+        offset=offset,
+        first_start=first_start,
+        duration_seconds=duration_seconds,
+        responsible=list(data.get("responsible") or []),
+    )
     entry.recurrences.append(rec)
     if not is_admin and has_past_instances(entry):
         raise HTTPException(status_code=400, detail="Cannot modify entry with past instances")

--- a/migrations/versions/16f872f43a3c_apply_entry_times_to_recurrences.py
+++ b/migrations/versions/16f872f43a3c_apply_entry_times_to_recurrences.py
@@ -51,7 +51,7 @@ def upgrade() -> None:
         conn.execute(
             sa.update(calendarentry)
             .where(calendarentry.c.id == entry_id)
-            .values(recurrences=json.dumps(updated))
+            .values(recurrences=updated)
         )
 
 
@@ -79,5 +79,5 @@ def downgrade() -> None:
         conn.execute(
             sa.update(calendarentry)
             .where(calendarentry.c.id == entry_id)
-            .values(recurrences=json.dumps(recurrences))
+            .values(recurrences=recurrences)
         )

--- a/migrations/versions/16f872f43a3c_apply_entry_times_to_recurrences.py
+++ b/migrations/versions/16f872f43a3c_apply_entry_times_to_recurrences.py
@@ -1,0 +1,83 @@
+"""apply entry first_start and duration to recurrences
+
+Revision ID: 16f872f43a3c
+Revises: 37f3cc068d39
+Create Date: 2025-09-03 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import json
+
+revision: str = '16f872f43a3c'
+down_revision: Union[str, Sequence[str], None] = '37f3cc068d39'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    metadata = sa.MetaData()
+    calendarentry = sa.Table(
+        'calendarentry',
+        metadata,
+        sa.Column('id', sa.Integer),
+        sa.Column('first_start', sa.DateTime()),
+        sa.Column('duration_seconds', sa.Integer()),
+        sa.Column('recurrences', sa.JSON()),
+    )
+    rows = conn.execute(
+        sa.select(
+            calendarentry.c.id,
+            calendarentry.c.first_start,
+            calendarentry.c.duration_seconds,
+            calendarentry.c.recurrences,
+        )
+    ).fetchall()
+    for entry_id, first_start, duration, recurrences in rows:
+        if not recurrences:
+            continue
+        if isinstance(recurrences, str):
+            recurrences = json.loads(recurrences)
+        start_str = first_start if isinstance(first_start, str) else first_start.isoformat()
+        updated = []
+        for rec in recurrences:
+            if not isinstance(rec, dict):
+                rec = dict(rec)
+            rec['first_start'] = start_str
+            rec['duration_seconds'] = duration
+            updated.append(rec)
+        conn.execute(
+            sa.update(calendarentry)
+            .where(calendarentry.c.id == entry_id)
+            .values(recurrences=json.dumps(updated))
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    metadata = sa.MetaData()
+    calendarentry = sa.Table(
+        'calendarentry',
+        metadata,
+        sa.Column('id', sa.Integer),
+        sa.Column('recurrences', sa.JSON()),
+    )
+    rows = conn.execute(
+        sa.select(calendarentry.c.id, calendarentry.c.recurrences)
+    ).fetchall()
+    for entry_id, recurrences in rows:
+        if not recurrences:
+            continue
+        if isinstance(recurrences, str):
+            recurrences = json.loads(recurrences)
+        for rec in recurrences:
+            if isinstance(rec, dict):
+                rec.pop('first_start', None)
+                rec.pop('duration_seconds', None)
+        conn.execute(
+            sa.update(calendarentry)
+            .where(calendarentry.c.id == entry_id)
+            .values(recurrences=json.dumps(recurrences))
+        )

--- a/tests/test_migration_recurrence_json.py
+++ b/tests/test_migration_recurrence_json.py
@@ -41,5 +41,5 @@ def test_migration_applies_times_and_stores_array(tmp_path):
             sa.select(calendarentry.c.recurrences).where(calendarentry.c.id == 1)
         ).scalar_one()
         assert isinstance(result, list)
-        assert result[0]["first_start"] == "2000-01-01T00:00:00"
+        assert result[0]["first_start"] == "2000-01-08T00:00:00"
         assert result[0]["duration_seconds"] == 3600

--- a/tests/test_migration_recurrence_json.py
+++ b/tests/test_migration_recurrence_json.py
@@ -1,0 +1,45 @@
+import importlib
+from datetime import datetime
+
+import sqlalchemy as sa
+from alembic import op
+
+migration = importlib.import_module(
+    "migrations.versions.16f872f43a3c_apply_entry_times_to_recurrences"
+)
+
+
+def test_migration_applies_times_and_stores_array(tmp_path):
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    calendarentry = sa.Table(
+        "calendarentry",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("first_start", sa.DateTime()),
+        sa.Column("duration_seconds", sa.Integer()),
+        sa.Column("recurrences", sa.JSON()),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.insert(calendarentry),
+            {
+                "id": 1,
+                "first_start": datetime(2000, 1, 1),
+                "duration_seconds": 3600,
+                "recurrences": [{"type": "Weekly"}],
+            },
+        )
+        original_get_bind = op.get_bind
+        op.get_bind = lambda: conn
+        try:
+            migration.upgrade()
+        finally:
+            op.get_bind = original_get_bind
+        result = conn.execute(
+            sa.select(calendarentry.c.recurrences).where(calendarentry.c.id == 1)
+        ).scalar_one()
+        assert isinstance(result, list)
+        assert result[0]["first_start"] == "2000-01-01T00:00:00"
+        assert result[0]["duration_seconds"] == 3600

--- a/tests/test_recurrence_first_start_duration.py
+++ b/tests/test_recurrence_first_start_duration.py
@@ -1,0 +1,54 @@
+import sys
+import importlib
+from pathlib import Path
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+    enumerate_time_periods,
+)
+from itertools import islice
+
+
+def test_recurrence_first_start_duration(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+
+    start = datetime(2000, 1, 1, 0, 0, tzinfo=ZoneInfo("UTC"))
+    rec_start = datetime(2000, 1, 8, 0, 0, tzinfo=ZoneInfo("UTC"))
+
+    entry = CalendarEntry(
+        title="Task",
+        description="",
+        type=CalendarEntryType.Chore,
+        first_start=start,
+        duration_seconds=3600,
+        recurrences=[
+            Recurrence(
+                type=RecurrenceType.Weekly,
+                first_start=rec_start,
+                duration_seconds=600,
+            )
+        ],
+        responsible=["Admin"],
+        managers=["Admin"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+    entry = app_module.calendar_store.get(entry_id)
+
+    periods = list(islice(enumerate_time_periods(entry), 2))
+    assert periods[0].start == start
+    assert periods[0].end - periods[0].start == timedelta(seconds=3600)
+    assert periods[1].start == rec_start
+    assert periods[1].end - periods[1].start == timedelta(seconds=600)


### PR DESCRIPTION
## Summary
- allow Recurrence objects to specify their own `first_start` and `duration_seconds`
- let API endpoints set these fields
- cover recurrence overrides with new tests

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b7cb233fd4832ca237a6a955bedf3a