### PR TITLE
feat: make test cross-platform

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -53,12 +53,23 @@ way to run the suite is via the provided make target:
 make test
 ```
 
-Under the hood this executes:
+This command works in both POSIX shells and PowerShell. If your Python
+interpreter is not available as `python` (for example on some Windows
+setups), override it with the `PYTHON` variable:
+
+```powershell
+make PYTHON=py test
+```
+
+Under the hood the make target executes:
 
 ```bash
 CHORETRACKER_SECRET_KEY=test CHORETRACKER_DISABLE_CSRF=1 \
 uv run --with pytest --with httpx -m pytest
 ```
+
+The `uv` command must be installed and on your `PATH`. See the
+prerequisites section above for installation instructions.
 
 ## Running the Development Server
 From the PyCharm terminal or a system shell, start the server with:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: docker-start docker-stop docker-rebuild test
 
+PYTHON ?= python
+
 docker-start:
 	docker compose up --no-build -d
 
@@ -11,4 +13,4 @@ docker-rebuild:
 	docker compose up -d
 
 test:
-	./scripts/test.sh
+	$(PYTHON) scripts/test.py

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+import os
+import subprocess
+import sys
+
+
+def main(argv: list[str]) -> int:
+    os.environ.setdefault("CHORETRACKER_SECRET_KEY", "test")
+    os.environ.setdefault("CHORETRACKER_DISABLE_CSRF", "1")
+    cmd = [
+        "uv",
+        "run",
+        "--with",
+        "pytest",
+        "--with",
+        "httpx",
+        "-m",
+        "pytest",
+        *argv,
+    ]
+    try:
+        return subprocess.call(cmd)
+    except FileNotFoundError:
+        raise SystemExit(
+            "uv is required to run tests. See DEVELOPMENT.md for installation instructions."
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export CHORETRACKER_SECRET_KEY="${CHORETRACKER_SECRET_KEY:-test}"
-export CHORETRACKER_DISABLE_CSRF="${CHORETRACKER_DISABLE_CSRF:-1}"
-
-uv run --with pytest --with httpx -m pytest "$@"
+PYTHON="${PYTHON:-python}"
+"$PYTHON" "$(dirname "$0")/test.py" "$@"


### PR DESCRIPTION
## Summary
- run tests through a Python wrapper so `make test` works in PowerShell
- allow overriding interpreter with `PYTHON` in the Makefile
- document Windows usage and uv requirement

## Testing
- `make test` *(fails: ImportError: cannot import name 'Offset' from 'choretracker.calendar')*

------
https://chatgpt.com/codex/tasks/task_e_68ba743f39d8832cae9e2d7f78a0e091