### PR TITLE
Use recurrence IDs throughout UI

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -1514,6 +1514,18 @@ async def remove_delegation(request: Request, entry_id: int):
         if d.instance_index == iindex:
             del rec.delegations[idx]
             break
+    specs = getattr(rec, "instance_specifics", {})
+    spec = specs.get(iindex)
+    if spec:
+        spec.responsible = None
+        if (
+            not spec.skip
+            and spec.duration_seconds is None
+            and spec.responsible is None
+            and spec.note is None
+        ):
+            del specs[iindex]
+    setattr(rec, "instance_specifics", specs)
     calendar_store.update(entry_id, entry)
     referer = request.headers.get(
         "referer",

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -12,15 +12,15 @@
     {% if entry.type == CalendarEntryType.Chore %}
         {% if period.end <= now %}
             {% if not completion and user_has(request.session.get('user'), 'chores.complete_overdue') %}
-            <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" data-action="add" />
+            <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rid="{{ period.recurrence_id }}" data-iindex="{{ period.instance_index }}" data-action="add" />
             {% elif completion %}
-            <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" {% if completion.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
+            <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rid="{{ period.recurrence_id }}" data-iindex="{{ period.instance_index }}" {% if completion.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
             {% endif %}
         {% elif period.start <= now %}
             {% if completion %}
-            <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" {% if completion.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
+            <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rid="{{ period.recurrence_id }}" data-iindex="{{ period.instance_index }}" {% if completion.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
             {% elif user_has(request.session.get('user'), 'chores.complete_on_time') %}
-            <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" data-action="add" />
+            <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rid="{{ period.recurrence_id }}" data-iindex="{{ period.instance_index }}" data-action="add" />
             {% endif %}
         {% endif %}
         {% if completion %}
@@ -31,7 +31,7 @@
 <div class="description">{{ entry.description|markdown|safe }}</div>
 {% if can_edit %}
 <form method="post" action="{{ url_for(is_skipped and 'unskip_instance' or 'skip_instance', entry_id=entry.id) }}">
-    <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
+    <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
     <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
     <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
     <button type="submit" class="skip-button">{{ 'Do not skip this instance' if is_skipped else 'Skip this instance' }}</button>
@@ -44,7 +44,7 @@
         {% if duration_override %}
             <button type="button" id="edit-duration" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
             <form method="post" action="{{ url_for('remove_instance_duration', entry_id=entry.id) }}" style="display:inline" id="delete-duration-form">
-                <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
+                <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
                 <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
                 <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
                 <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
@@ -57,7 +57,7 @@
     <div id="duration-display" class="duration-display" data-duration-seconds="{{ duration_override.total_seconds()|int }}">{{ duration_override|format_duration }}</div>
     {% endif %}
     <form method="post" action="{{ url_for('set_instance_duration', entry_id=entry.id) }}" id="duration-editor" style="display:none">
-        <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
+        <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
         <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
         <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
         <div class="duration-inputs">
@@ -86,7 +86,7 @@
             {% if can_edit %}
             <button type="button" id="edit-note" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
             <form method="post" action="{{ url_for('remove_instance_note', entry_id=entry.id) }}" style="display:inline" id="delete-note-form">
-                <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
+                <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
                 <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
                 <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
                 <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
@@ -101,7 +101,7 @@
     {% endif %}
     {% if can_edit %}
     <form method="post" action="{{ url_for('add_instance_note', entry_id=entry.id) }}" id="note-editor" style="display:none">
-        <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
+        <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
         <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
         <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
         <textarea name="note" rows="4" cols="40">{{ note or '' }}</textarea>
@@ -119,7 +119,7 @@
     {% if delegation and can_edit %}
     <button type="button" id="edit-delegation" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
     <form method="post" action="{{ url_for('remove_delegation', entry_id=entry.id) }}" style="display:inline">
-        <input type="hidden" name="recurrence_index" value="{{ period.recurrence_index }}" />
+        <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
         <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
         <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
         <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
@@ -143,21 +143,21 @@
 document.querySelectorAll('.checkbox-icon[data-action]').forEach(el => {
     el.addEventListener('click', async () => {
         const entry = el.dataset.entry;
-        const r = parseInt(el.dataset.rindex);
+        const r = parseInt(el.dataset.rid);
         const i = parseInt(el.dataset.iindex);
         const url = el.dataset.action === 'add' ? `/calendar/${entry}/completion` : `/calendar/${entry}/completion/remove`;
         await fetch(url, {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             credentials: 'same-origin',
-            body: JSON.stringify({recurrence_index: r, instance_index: i})
+            body: JSON.stringify({recurrence_id: r, instance_index: i})
         });
         location.reload();
     });
 });
 document.addEventListener('DOMContentLoaded', () => {
     const entryId = {{ entry.id }};
-    const rindex = {{ period.recurrence_index }};
+    const rid = {{ period.recurrence_id }};
     const iindex = {{ period.instance_index }};
     const csrfToken = {{ request.session.get('csrf_token', '')|tojson }};
     const allUsers = {{ all_users()|selectattr('username','ne','Viewer')|map(attribute='username')|list|tojson }};
@@ -391,7 +391,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
             const form = new FormData();
-            form.append('recurrence_index', rindex);
+            form.append('recurrence_id', rid);
             form.append('instance_index', iindex);
             form.append('csrf_token', csrfToken);
             delegates.forEach(u => form.append('responsible[]', u));

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -54,7 +54,7 @@
         {% if entry.recurrences %}
         <ul id="recurrence-list">
             {% for rec in entry.recurrences %}
-            <li class="recurrence-item" data-rindex="{{ loop.index0 }}" data-type="{{ rec.type.value }}" data-responsible='{{ rec.responsible|tojson }}'>
+            <li class="recurrence-item" data-rid="{{ rec.id }}" data-type="{{ rec.type.value }}" data-responsible='{{ rec.responsible|tojson }}'>
                 <span class="recurrence-text">{{ rec.type.value }}</span>
                 {% for user in rec.responsible %}
                 <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
@@ -95,7 +95,7 @@
             <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
             {% endfor %}
             {% if completion %}
-            <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ completion.recurrence_index }}" data-iindex="{{ completion.instance_index }}" {% if can_remove %}data-action="remove"{% endif %} />
+            <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rid="{{ completion.recurrence_id }}" data-iindex="{{ completion.instance_index }}" {% if can_remove %}data-action="remove"{% endif %} />
             <img src="{{ url_for('profile_picture', username=completion.completed_by) }}" alt="{{ completion.completed_by }}" class="profile-icon" />
             {{ completion.completed_at|format_completion_time(period.end) }}
             {% endif %}
@@ -123,13 +123,13 @@
 document.querySelectorAll('.checkbox-icon[data-action="remove"]').forEach(el => {
     el.addEventListener('click', async () => {
         const entry = el.dataset.entry;
-        const r = parseInt(el.dataset.rindex);
+        const r = parseInt(el.dataset.rid);
         const i = parseInt(el.dataset.iindex);
         await fetch(`/calendar/${entry}/completion/remove`, {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             credentials: 'same-origin',
-            body: JSON.stringify({recurrence_index: r, instance_index: i})
+            body: JSON.stringify({recurrence_id: r, instance_index: i})
         });
         location.reload();
     });
@@ -369,7 +369,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const recContainer = document.getElementById('recurrence-container');
     let recList = document.getElementById('recurrence-list');
 
-    function setupRecurrenceEditor(li, rindex, originalType, originalResp, isNew) {
+    function setupRecurrenceEditor(li, rid, originalType, originalResp, isNew) {
         if (isNew && addRecurrence) {
             addRecurrence.style.display = 'none';
         }
@@ -459,7 +459,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 payload.first_start = defaultFirstStart;
                 payload.duration_seconds = defaultDurationSeconds;
             } else {
-                payload.recurrence_id = rindex;
+                payload.recurrence_id = rid;
             }
             const resp = await fetch(url, {
                 method: 'POST',
@@ -496,22 +496,22 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.recurrence-item .edit-recurrence').forEach(btn => {
         btn.addEventListener('click', () => {
             const li = btn.closest('.recurrence-item');
-            const rindex = parseInt(li.dataset.rindex);
+            const rid = parseInt(li.dataset.rid);
             const originalType = li.dataset.type;
             const originalResp = JSON.parse(li.dataset.responsible || '[]');
-            setupRecurrenceEditor(li, rindex, originalType, originalResp, false);
+            setupRecurrenceEditor(li, rid, originalType, originalResp, false);
         });
     });
 
     document.querySelectorAll('.recurrence-item .delete-recurrence').forEach(btn => {
         btn.addEventListener('click', async () => {
             const li = btn.closest('.recurrence-item');
-            const rindex = parseInt(li.dataset.rindex);
+            const rid = parseInt(li.dataset.rid);
             const resp = await fetch(`/calendar/${entryId}/recurrence/delete`, {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
                 credentials: 'same-origin',
-                body: JSON.stringify({recurrence_id: rindex})
+                body: JSON.stringify({recurrence_id: rid})
             });
             if (resp.ok) {
                 const data = await resp.json();
@@ -538,7 +538,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const li = document.createElement('li');
             li.className = 'recurrence-item';
             recList.appendChild(li);
-            setupRecurrenceEditor(li, recList.children.length - 1, recurrenceTypes[0], [], true);
+            setupRecurrenceEditor(li, -1, recurrenceTypes[0], [], true);
         });
     }
 

--- a/choretracker/templates/completions/list.html
+++ b/choretracker/templates/completions/list.html
@@ -9,9 +9,9 @@
     {% for entry, comp, has_note in today %}
     <li>
         <img src="{{ url_for('profile_picture', username=comp.completed_by) }}" alt="{{ comp.completed_by }}" class="profile-icon" />
-        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=comp.recurrence_index, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %}</a>
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, recurrence_id=comp.recurrence_id, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %}</a>
         {{ comp.completed_at|format_datetime(True) }}
-        <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ comp.recurrence_index }}" data-iindex="{{ comp.instance_index }}" {% if comp.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
+        <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rid="{{ comp.recurrence_id }}" data-iindex="{{ comp.instance_index }}" {% if comp.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
     </li>
     {% endfor %}
 </ul>
@@ -22,9 +22,9 @@
     {% for entry, comp, has_note in yesterday %}
     <li>
         <img src="{{ url_for('profile_picture', username=comp.completed_by) }}" alt="{{ comp.completed_by }}" class="profile-icon" />
-        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=comp.recurrence_index, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %}</a>
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, recurrence_id=comp.recurrence_id, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %}</a>
         {{ comp.completed_at|format_datetime(True) }}
-        <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ comp.recurrence_index }}" data-iindex="{{ comp.instance_index }}" {% if comp.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
+        <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rid="{{ comp.recurrence_id }}" data-iindex="{{ comp.instance_index }}" {% if comp.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
     </li>
     {% endfor %}
 </ul>
@@ -35,9 +35,9 @@
     {% for entry, comp, has_note in earlier %}
     <li>
         <img src="{{ url_for('profile_picture', username=comp.completed_by) }}" alt="{{ comp.completed_by }}" class="profile-icon" />
-        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=comp.recurrence_index, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %}</a>
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, recurrence_id=comp.recurrence_id, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %}</a>
         {{ comp.completed_at|format_datetime(True) }}
-        <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ comp.recurrence_index }}" data-iindex="{{ comp.instance_index }}" {% if comp.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
+        <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rid="{{ comp.recurrence_id }}" data-iindex="{{ comp.instance_index }}" {% if comp.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
     </li>
     {% endfor %}
 </ul>
@@ -49,7 +49,7 @@
 document.querySelectorAll('.checkbox-icon[data-action]').forEach(el => {
     el.addEventListener('click', async () => {
         const entry = el.dataset.entry;
-        const r = parseInt(el.dataset.rindex);
+        const r = parseInt(el.dataset.rid);
         const i = parseInt(el.dataset.iindex);
         const url = el.dataset.action === 'add'
             ? `/calendar/${entry}/completion`
@@ -58,7 +58,7 @@ document.querySelectorAll('.checkbox-icon[data-action]').forEach(el => {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             credentials: 'same-origin',
-            body: JSON.stringify({recurrence_index: r, instance_index: i})
+            body: JSON.stringify({recurrence_id: r, instance_index: i})
         });
         location.reload();
     });

--- a/choretracker/templates/index.html
+++ b/choretracker/templates/index.html
@@ -11,10 +11,10 @@
         {% for user in responsible %}
         <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, recurrence_id=period.recurrence_id, iindex=period.instance_index) }}">{{ entry.title }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
         <span class="time-suffix" data-kind="due-ago" data-end="{{ period.end.timestamp() }}"></span>
         {% if entry.type == CalendarEntryType.Chore %}
-        <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" data-action="add" />
+        <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rid="{{ period.recurrence_id }}" data-iindex="{{ period.instance_index }}" data-action="add" />
         {% endif %}
     </li>
     {% endfor %}
@@ -29,13 +29,13 @@
         {% for user in responsible %}
         <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, recurrence_id=period.recurrence_id, iindex=period.instance_index) }}">{{ entry.title }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
         {% if entry.type == CalendarEntryType.Chore %}
         {% if completion %}
-        <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" {% if completion.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
+        <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rid="{{ period.recurrence_id }}" data-iindex="{{ period.instance_index }}" {% if completion.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
         {% else %}
         <span class="time-suffix" data-kind="due-in" data-end="{{ period.end.timestamp() }}"></span>
-        <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rindex="{{ period.recurrence_index }}" data-iindex="{{ period.instance_index }}" data-action="add" />
+        <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rid="{{ period.recurrence_id }}" data-iindex="{{ period.instance_index }}" data-action="add" />
         {% endif %}
         {% endif %}
     </li>
@@ -51,7 +51,7 @@
         {% for user in responsible %}
         <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        <a href="{{ url_for('view_time_period', entry_id=entry.id, rindex=period.recurrence_index, iindex=period.instance_index) }}">{{ entry.title }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, recurrence_id=period.recurrence_id, iindex=period.instance_index) }}">{{ entry.title }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
         <span class="time-suffix" data-kind="starts-in" data-start="{{ period.start.timestamp() }}"></span>
     </li>
     {% endfor %}
@@ -110,7 +110,7 @@ setInterval(updateTimes, 1000);
 document.querySelectorAll('.checkbox-icon[data-action]').forEach(el => {
     el.addEventListener('click', async () => {
         const entry = el.dataset.entry;
-        const r = parseInt(el.dataset.rindex);
+        const r = parseInt(el.dataset.rid);
         const i = parseInt(el.dataset.iindex);
         const url = el.dataset.action === 'add'
             ? `/calendar/${entry}/completion`
@@ -119,7 +119,7 @@ document.querySelectorAll('.checkbox-icon[data-action]').forEach(el => {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             credentials: 'same-origin',
-            body: JSON.stringify({recurrence_index: r, instance_index: i})
+            body: JSON.stringify({recurrence_id: r, instance_index: i})
         });
         if (resp.status === 403) {
             const data = await resp.json();

--- a/choretracker/templates/users/view.html
+++ b/choretracker/templates/users/view.html
@@ -8,7 +8,7 @@
 <h2>Completions</h2>
 <ul>
     {% for entry, comp, has_note in completions %}
-    <li><a href="{{ url_for('view_time_period', entry_id=comp.entry_id, rindex=comp.recurrence_index, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %} {{ comp.completed_at|format_datetime(True) }}</a></li>
+    <li><a href="{{ url_for('view_time_period', entry_id=comp.entry_id, recurrence_id=comp.recurrence_id, iindex=comp.instance_index) }}">{{ entry.title }}{% if has_note %}<span class="note-marker">*</span>{% endif %} {{ comp.completed_at|format_datetime(True) }}</a></li>
     {% else %}
     <li>No completions found.</li>
     {% endfor %}


### PR DESCRIPTION
## Summary
- Replace old `recurrence_index` parameters with `recurrence_id` in templates and JavaScript
- Clean up delegation removal by clearing instance-specific data
- Update delegation test for new recurrence ID model

## Testing
- `make test` *(fails: ImportError: cannot import name 'Offset' from 'choretracker.calendar')*
- `python scripts/test.py tests/test_delegate_instance.py tests/test_calendar_entry_instances.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb148339e0832cabafcac483b79492