### PR TITLE
Define business-only instance specifics on Recurrence

### DIFF
--- a/tests/test_calendar_entry_instances.py
+++ b/tests/test_calendar_entry_instances.py
@@ -40,10 +40,8 @@ def test_instances_past_and_upcoming(tmp_path, monkeypatch):
         first_start=datetime(2000, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC")),
         duration_seconds=3600,
     )
-    object.__setattr__(
-        rec,
-        "instance_specifics",
-        {1: InstanceSpecifics(entry_id=0, recurrence_id=0, instance_index=1, skip=True)},
+    rec.instance_specifics[1] = InstanceSpecifics(
+        entry_id=0, recurrence_id=0, instance_index=1, skip=True
     )
     entry = CalendarEntry(
         title="Dishes",

--- a/tests/test_delegate_instance.py
+++ b/tests/test_delegate_instance.py
@@ -9,7 +9,13 @@ from fastapi.testclient import TestClient
 # Ensure project root on path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from choretracker.calendar import CalendarEntry, CalendarEntryType, Recurrence, RecurrenceType, responsible_for
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+    responsible_for,
+)
 
 
 def test_delegate_instance(tmp_path, monkeypatch):
@@ -52,11 +58,8 @@ def test_delegate_instance(tmp_path, monkeypatch):
     rec = entry.recurrences[0]
     if not isinstance(rec, Recurrence):
         rec = Recurrence.model_validate(rec)
-    from choretracker.calendar import Delegation
-    deleg = rec.delegations[0]
-    if not isinstance(deleg, Delegation):
-        deleg = Delegation.model_validate(deleg)
-    assert deleg.responsible == ["Bob"]
+    spec = rec.instance_specifics[0]
+    assert spec.responsible == ["Bob"]
     assert responsible_for(entry, 0, 0) == ["Bob"]
 
     page = client.get(f"/calendar/entry/{entry_id}/period/0/0")

--- a/tests/test_responsible_overrides.py
+++ b/tests/test_responsible_overrides.py
@@ -8,7 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from choretracker.calendar import (
     CalendarEntry,
     CalendarEntryType,
-    Delegation,
+    InstanceSpecifics,
     Recurrence,
     RecurrenceType,
     responsible_for,
@@ -16,26 +16,30 @@ from choretracker.calendar import (
 
 
 def test_responsible_hierarchy():
+    rec = Recurrence(
+        id=0,
+        type=RecurrenceType.Weekly,
+        responsible=["alice"],
+    )
+    rec.instance_specifics[1] = InstanceSpecifics(
+        entry_id=0, recurrence_id=0, instance_index=1, responsible=["bob"]
+    )
     entry = CalendarEntry(
         title="Test",
         description="",
         type=CalendarEntryType.Chore,
         first_start=get_now(),
         duration_seconds=60,
-        recurrences=[
-            Recurrence(
-                type=RecurrenceType.Weekly,
-                responsible=["alice"],
-                delegations=[Delegation(instance_index=1, responsible=["bob"])]
-            )
-        ],
+        recurrences=[rec],
         responsible=["carol"],
     )
 
     assert responsible_for(entry, 0, 0) == ["alice"]
     assert responsible_for(entry, 0, 1) == ["bob"]
     entry.recurrences[0].responsible = []
-    entry.recurrences[0].delegations = []
+    entry.recurrences[0].instance_specifics.pop(1)
     assert responsible_for(entry, 0, 2) == ["carol"]
-    entry.recurrences[0].delegations = [Delegation(instance_index=3, responsible=[])]
+    entry.recurrences[0].instance_specifics[3] = InstanceSpecifics(
+        entry_id=0, recurrence_id=0, instance_index=3, responsible=[]
+    )
     assert responsible_for(entry, 0, 3) == []

--- a/tests/test_username_change_updates.py
+++ b/tests/test_username_change_updates.py
@@ -11,7 +11,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from choretracker.calendar import (
     CalendarEntry,
     CalendarEntryType,
-    Delegation,
+    InstanceSpecifics,
     Recurrence,
     RecurrenceType,
 )
@@ -35,11 +35,14 @@ def test_username_change_updates_references(tmp_path, monkeypatch):
         managers=["Bob"],
         recurrences=[
             Recurrence(
+                id=0,
                 type=RecurrenceType.Weekly,
                 responsible=["Bob"],
-                delegations=[Delegation(instance_index=0, responsible=["Bob"])],
             )
         ],
+    )
+    entry.recurrences[0].instance_specifics[0] = InstanceSpecifics(
+        entry_id=0, recurrence_id=0, instance_index=0, responsible=["Bob"]
     )
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[0].id
@@ -66,7 +69,7 @@ def test_username_change_updates_references(tmp_path, monkeypatch):
     assert entry.managers == ["Bobby"]
     assert entry.responsible == ["Bobby"]
     assert entry.recurrences[0].responsible == ["Bobby"]
-    assert entry.recurrences[0].delegations[0].responsible == ["Bobby"]
+    assert entry.recurrences[0].instance_specifics[0].responsible == ["Bobby"]
 
     comp = app_module.completion_store.list_for_entry(entry_id)[0]
     assert comp.completed_by == "Bobby"


### PR DESCRIPTION
## Summary
- drop legacy delegation/note/duration fields from Recurrence and use InstanceSpecifics for per-instance data
- update calendar, user management, and tests to read/write delegation info via instance_specifics

## Testing
- `python scripts/test.py tests/test_delegate_instance.py tests/test_calendar_entry_instances.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb1986d010832c92de9c4f753841df