### PR TITLE
Align failing tests with new data model

### DIFF
--- a/tests/test_calendar_list_active_past.py
+++ b/tests/test_calendar_list_active_past.py
@@ -9,7 +9,12 @@ from fastapi.testclient import TestClient
 # Ensure project root is on path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from choretracker.calendar import CalendarEntry, CalendarEntryType
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+)
 
 
 def test_list_active_and_past(tmp_path, monkeypatch):
@@ -25,32 +30,56 @@ def test_list_active_and_past(tmp_path, monkeypatch):
         title="Future 2",
         description="",
         type=CalendarEntryType.Event,
-        first_start=now + timedelta(days=2),
-        duration_seconds=60,
+        recurrences=[
+            Recurrence(
+                id=0,
+                type=RecurrenceType.OneTime,
+                first_start=now + timedelta(days=2),
+                duration_seconds=60,
+            )
+        ],
         managers=["Admin"],
     )
     active_older = CalendarEntry(
         title="Future 1",
         description="",
         type=CalendarEntryType.Event,
-        first_start=now + timedelta(days=1),
-        duration_seconds=60,
+        recurrences=[
+            Recurrence(
+                id=0,
+                type=RecurrenceType.OneTime,
+                first_start=now + timedelta(days=1),
+                duration_seconds=60,
+            )
+        ],
         managers=["Admin"],
     )
     past_newer = CalendarEntry(
         title="Past 1",
         description="",
         type=CalendarEntryType.Event,
-        first_start=now - timedelta(days=1),
-        duration_seconds=60,
+        recurrences=[
+            Recurrence(
+                id=0,
+                type=RecurrenceType.OneTime,
+                first_start=now - timedelta(days=1),
+                duration_seconds=60,
+            )
+        ],
         managers=["Admin"],
     )
     past_older = CalendarEntry(
         title="Past 2",
         description="",
         type=CalendarEntryType.Event,
-        first_start=now - timedelta(days=2),
-        duration_seconds=60,
+        recurrences=[
+            Recurrence(
+                id=0,
+                type=RecurrenceType.OneTime,
+                first_start=now - timedelta(days=2),
+                duration_seconds=60,
+            )
+        ],
         managers=["Admin"],
     )
     app_module.calendar_store.create(active_newer)

--- a/tests/test_calendar_list_disambiguation.py
+++ b/tests/test_calendar_list_disambiguation.py
@@ -9,7 +9,12 @@ from fastapi.testclient import TestClient
 # Ensure project root is on path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from choretracker.calendar import CalendarEntry, CalendarEntryType
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+)
 
 
 def test_duplicate_titles_disambiguated(tmp_path, monkeypatch):
@@ -24,16 +29,28 @@ def test_duplicate_titles_disambiguated(tmp_path, monkeypatch):
         title="Guinea salad",
         description="",
         type=CalendarEntryType.Event,
-        first_start=datetime(2025, 8, 22, 8, 0, 0, tzinfo=ZoneInfo("UTC")),
-        duration_seconds=60,
+        recurrences=[
+            Recurrence(
+                id=0,
+                type=RecurrenceType.OneTime,
+                first_start=datetime(2025, 8, 22, 8, 0, 0, tzinfo=ZoneInfo("UTC")),
+                duration_seconds=60,
+            )
+        ],
         managers=["Admin"],
     )
     second = CalendarEntry(
         title="Guinea salad",
         description="",
         type=CalendarEntryType.Event,
-        first_start=datetime(2025, 8, 23, 8, 0, 0, tzinfo=ZoneInfo("UTC")),
-        duration_seconds=60,
+        recurrences=[
+            Recurrence(
+                id=0,
+                type=RecurrenceType.OneTime,
+                first_start=datetime(2025, 8, 23, 8, 0, 0, tzinfo=ZoneInfo("UTC")),
+                duration_seconds=60,
+            )
+        ],
         managers=["Admin"],
     )
     app_module.calendar_store.create(first)

--- a/tests/test_chore_completions_page.py
+++ b/tests/test_chore_completions_page.py
@@ -32,21 +32,27 @@ def test_chore_completions_sections(tmp_path, monkeypatch):
         title="Task",
         description="",
         type=app_module.CalendarEntryType.Chore,
-        first_start=fake_now - timedelta(days=5),
-        duration_seconds=60,
+        recurrences=[
+            app_module.Recurrence(
+                id=0,
+                type=app_module.RecurrenceType.OneTime,
+                first_start=fake_now - timedelta(days=5),
+                duration_seconds=60,
+            )
+        ],
         managers=["Admin"],
     )
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[0].id
 
     app_module.completion_store.create(
-        entry_id, -1, -1, "Admin", completed_at=fake_now - timedelta(hours=1)
+        entry_id, 0, 0, "Admin", completed_at=fake_now - timedelta(hours=1)
     )
     app_module.completion_store.create(
-        entry_id, -1, -1, "Admin", completed_at=fake_now - timedelta(days=1, hours=1)
+        entry_id, 0, 0, "Admin", completed_at=fake_now - timedelta(days=1, hours=1)
     )
     app_module.completion_store.create(
-        entry_id, -1, -1, "Admin", completed_at=fake_now - timedelta(days=2)
+        entry_id, 0, 0, "Admin", completed_at=fake_now - timedelta(days=2)
     )
 
     response = client.get("/chore_completions")
@@ -79,15 +85,21 @@ def test_completions_page_shows_remove_icon(tmp_path, monkeypatch):
         title="Task",
         description="",
         type=app_module.CalendarEntryType.Chore,
-        first_start=fake_now - timedelta(days=1),
-        duration_seconds=60,
+        recurrences=[
+            app_module.Recurrence(
+                id=0,
+                type=app_module.RecurrenceType.OneTime,
+                first_start=fake_now - timedelta(days=1),
+                duration_seconds=60,
+            )
+        ],
         managers=["Admin"],
     )
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[0].id
 
     app_module.completion_store.create(
-        entry_id, -1, -1, "Admin", completed_at=fake_now - timedelta(hours=1)
+        entry_id, 0, 0, "Admin", completed_at=fake_now - timedelta(hours=1)
     )
 
     response = client.get("/chore_completions")


### PR DESCRIPTION
## Summary
- update calendar list tests to build `CalendarEntry` objects with explicit `Recurrence` data
- adjust chore completion tests to reference recurrence and instance indices

## Testing
- `python scripts/test.py tests/test_calendar_entry_instances.py`
- `python scripts/test.py tests/test_calendar_list_active_past.py::test_list_active_and_past`
- `python scripts/test.py tests/test_calendar_list_disambiguation.py::test_duplicate_titles_disambiguated`
- `python scripts/test.py tests/test_chore_completions_page.py`
- `python scripts/test.py tests/test_delegate_instance.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb3d953c6c832c9255fa03afc080c7