### PR TITLE
Update tests for recurrence-based calendar model

### DIFF
--- a/choretracker/calendar.py
+++ b/choretracker/calendar.py
@@ -291,6 +291,16 @@ class CalendarEntryStore:
             session.add(new_entry)
             session.commit()
 
+            # Ensure Recurrence objects after commit
+            entry.recurrences = [
+                r if isinstance(r, Recurrence) else Recurrence.model_validate(r)
+                for r in entry.recurrences
+            ]
+            new_entry.recurrences = [
+                r if isinstance(r, Recurrence) else Recurrence.model_validate(r)
+                for r in new_entry.recurrences
+            ]
+
             # Store instance specifics
             _store_instance_specifics(session, entry)
             _store_instance_specifics(session, new_entry)

--- a/tests/test_description_markdown.py
+++ b/tests/test_description_markdown.py
@@ -9,7 +9,12 @@ from fastapi.testclient import TestClient
 # Ensure project root is on path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from choretracker.calendar import CalendarEntry, CalendarEntryType
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+)
 
 
 def test_description_rendered_as_markdown(tmp_path, monkeypatch):
@@ -20,12 +25,17 @@ def test_description_rendered_as_markdown(tmp_path, monkeypatch):
 
     client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
 
+    rec = Recurrence(
+        id=0,
+        type=RecurrenceType.OneTime,
+        first_start=datetime(2025, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC")),
+        duration_seconds=60,
+    )
     entry = CalendarEntry(
         title="Markdown",
         description="**bold**",
         type=CalendarEntryType.Event,
-        first_start=datetime(2025, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC")),
-        duration_seconds=60,
+        recurrences=[rec],
         managers=["Admin"],
     )
     app_module.calendar_store.create(entry)

--- a/tests/test_description_sanitized.py
+++ b/tests/test_description_sanitized.py
@@ -10,7 +10,12 @@ import re
 # Ensure project root is on path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from choretracker.calendar import CalendarEntry, CalendarEntryType
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+)
 
 
 def test_description_sanitized(tmp_path, monkeypatch):
@@ -21,12 +26,17 @@ def test_description_sanitized(tmp_path, monkeypatch):
 
     client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
 
+    rec = Recurrence(
+        id=0,
+        type=RecurrenceType.OneTime,
+        first_start=datetime(2025, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC")),
+        duration_seconds=60,
+    )
     entry = CalendarEntry(
         title="Sanitize",
         description="<script>alert('x')</script>",
         type=CalendarEntryType.Event,
-        first_start=datetime(2025, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC")),
-        duration_seconds=60,
+        recurrences=[rec],
         managers=["Admin"],
     )
     app_module.calendar_store.create(entry)

--- a/tests/test_entry_managers.py
+++ b/tests/test_entry_managers.py
@@ -9,7 +9,12 @@ from fastapi.testclient import TestClient
 # Ensure project root on path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from choretracker.calendar import CalendarEntry, CalendarEntryType
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+)
 
 
 def test_edit_permissions(tmp_path, monkeypatch):
@@ -25,12 +30,17 @@ def test_edit_permissions(tmp_path, monkeypatch):
     app_module.user_store.create("Manager", "manager", None, set())
     app_module.user_store.create("Bob", "bob", None, set())
 
+    rec = Recurrence(
+        id=0,
+        type=RecurrenceType.OneTime,
+        first_start=datetime(2000, 1, 1, 0, 0, tzinfo=ZoneInfo("UTC")),
+        duration_seconds=60,
+    )
     entry = CalendarEntry(
         title="Test",
         description="",
         type=CalendarEntryType.Event,
-        first_start=datetime(2000, 1, 1, 0, 0, tzinfo=ZoneInfo("UTC")),
-        duration_seconds=60,
+        recurrences=[rec],
         managers=["Manager"],
     )
     app_module.calendar_store.create(entry)
@@ -95,12 +105,17 @@ def test_update_rejects_empty_managers(tmp_path, monkeypatch):
 
     client = TestClient(app_module.app)
 
+    rec = Recurrence(
+        id=0,
+        type=RecurrenceType.OneTime,
+        first_start=datetime(2000, 1, 1, 0, 0, tzinfo=ZoneInfo("UTC")),
+        duration_seconds=60,
+    )
     entry = CalendarEntry(
         title="Test",
         description="",
         type=CalendarEntryType.Event,
-        first_start=datetime(2000, 1, 1, 0, 0, tzinfo=ZoneInfo("UTC")),
-        duration_seconds=60,
+        recurrences=[rec],
         managers=["Admin"],
     )
     app_module.calendar_store.create(entry)

--- a/tests/test_first_instance_delegation.py
+++ b/tests/test_first_instance_delegation.py
@@ -9,7 +9,14 @@ from fastapi.testclient import TestClient
 # Ensure project root on path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from choretracker.calendar import CalendarEntry, CalendarEntryType, Recurrence, RecurrenceType, responsible_for
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+    responsible_for,
+    is_instance_skipped,
+)
 
 
 def test_delegate_first_instance(tmp_path, monkeypatch):
@@ -23,13 +30,17 @@ def test_delegate_first_instance(tmp_path, monkeypatch):
     client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
     app_module.user_store.create("Bob", "pw", None, set())
 
+    rec = Recurrence(
+        id=0,
+        type=RecurrenceType.Weekly,
+        first_start=datetime(2000, 1, 1, 8, 0, 0, tzinfo=ZoneInfo("UTC")),
+        duration_seconds=60,
+    )
     entry = CalendarEntry(
         title="Laundry",
         description="",
         type=CalendarEntryType.Chore,
-        first_start=datetime(2000, 1, 1, 8, 0, 0, tzinfo=ZoneInfo("UTC")),
-        duration_seconds=60,
-        recurrences=[Recurrence(type=RecurrenceType.Weekly)],
+        recurrences=[rec],
         responsible=["Admin"],
         managers=["Admin"],
     )
@@ -38,56 +49,55 @@ def test_delegate_first_instance(tmp_path, monkeypatch):
 
     resp = client.post(
         f"/calendar/{entry_id}/delegation",
-        data={"recurrence_index": -1, "instance_index": -1, "responsible[]": "Bob"},
+        data={"recurrence_id": 0, "instance_index": 0, "responsible[]": "Bob"},
         follow_redirects=False,
     )
     assert resp.status_code == 303
 
     entry = app_module.calendar_store.get(entry_id)
-    assert entry.first_instance_delegates == ["Bob"]
-    assert responsible_for(entry, -1, -1) == ["Bob"]
+    assert responsible_for(entry, 0, 0) == ["Bob"]
 
-    page = client.get(f"/calendar/entry/{entry_id}/period/-1/-1")
+    page = client.get(f"/calendar/entry/{entry_id}/period/0/0")
     assert "trash.svg" in page.text
     assert "pen.svg" in page.text
 
     resp = client.post(
         f"/calendar/{entry_id}/delegation/remove",
-        data={"recurrence_index": -1, "instance_index": -1},
+        data={"recurrence_id": 0, "instance_index": 0},
         follow_redirects=False,
     )
     assert resp.status_code == 303
 
     entry = app_module.calendar_store.get(entry_id)
-    assert entry.first_instance_delegates == []
-    page = client.get(f"/calendar/entry/{entry_id}/period/-1/-1")
+    assert responsible_for(entry, 0, 0) == ["Admin"]
+    page = client.get(f"/calendar/entry/{entry_id}/period/0/0")
     assert 'id="delegate-this-instance"' in page.text
 
     resp = client.post(
         f"/calendar/{entry_id}/delegation",
-        data={"recurrence_index": -1, "instance_index": -1, "responsible[]": "Bob"},
+        data={"recurrence_id": 0, "instance_index": 0, "responsible[]": "Bob"},
         follow_redirects=False,
     )
     assert resp.status_code == 303
 
     resp = client.post(
         f"/calendar/{entry_id}/skip",
-        data={"recurrence_index": -1, "instance_index": -1},
+        data={"recurrence_id": 0, "instance_index": 0},
         follow_redirects=False,
     )
     assert resp.status_code == 303
 
     entry = app_module.calendar_store.get(entry_id)
-    assert entry.first_instance_delegates == []
-    assert entry.skip_first_instance is True
-    page = client.get(f"/calendar/entry/{entry_id}/period/-1/-1")
+    assert responsible_for(entry, 0, 0) == ["Admin"]
+    assert is_instance_skipped(entry, 0, 0) is True
+    page = client.get(f"/calendar/entry/{entry_id}/period/0/0")
     assert 'id="delegate-this-instance"' not in page.text
     assert 'id="edit-delegation"' not in page.text
 
     client.post(
         f"/calendar/{entry_id}/skip/remove",
-        data={"recurrence_index": -1, "instance_index": -1},
+        data={"recurrence_id": 0, "instance_index": 0},
         follow_redirects=False,
     )
-    page = client.get(f"/calendar/entry/{entry_id}/period/-1/-1")
+    page = client.get(f"/calendar/entry/{entry_id}/period/0/0")
     assert 'id="delegate-this-instance"' in page.text

--- a/tests/test_hide_due_when_completed.py
+++ b/tests/test_hide_due_when_completed.py
@@ -9,7 +9,12 @@ from fastapi.testclient import TestClient
 # Ensure project root on path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from choretracker.calendar import CalendarEntry, CalendarEntryType
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+)
 import re
 
 
@@ -25,19 +30,24 @@ def test_due_not_shown_when_completed(tmp_path, monkeypatch):
     client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
 
     now = get_now()
+    rec = Recurrence(
+        id=0,
+        type=RecurrenceType.OneTime,
+        first_start=now - timedelta(minutes=5),
+        duration_seconds=3600,
+    )
     entry = CalendarEntry(
         title="Laundry",
         description="",
         type=CalendarEntryType.Chore,
-        first_start=now - timedelta(minutes=5),
-        duration_seconds=3600,
+        recurrences=[rec],
         managers=["Admin"],
+        responsible=["Admin"],
     )
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[0].id
 
-    # mark completion for the period (no recurrence -> indices -1, -1)
-    app_module.completion_store.create(entry_id, -1, -1, "Admin")
+    app_module.completion_store.create(entry_id, 0, 0, "Admin")
 
     response = client.get("/")
     assert "Laundry" in response.text

--- a/tests/test_index_sort_order.py
+++ b/tests/test_index_sort_order.py
@@ -9,7 +9,12 @@ from fastapi.testclient import TestClient
 # Ensure project root on path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from choretracker.calendar import CalendarEntry, CalendarEntryType
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+)
 
 
 def _setup_app(tmp_path, monkeypatch, fake_now):
@@ -36,40 +41,68 @@ def test_now_sorting(tmp_path, monkeypatch):
             title="Beta",
             description="",
             type=CalendarEntryType.Chore,
-            first_start=start,
-            duration_seconds=600,
+            recurrences=[
+                Recurrence(
+                    id=0,
+                    type=RecurrenceType.OneTime,
+                    first_start=start,
+                    duration_seconds=600,
+                )
+            ],
             managers=["Admin"],
+            responsible=["Admin"],
         ),
         CalendarEntry(
             title="Gamma",
             description="",
             type=CalendarEntryType.Chore,
-            first_start=start,
-            duration_seconds=600,
+            recurrences=[
+                Recurrence(
+                    id=0,
+                    type=RecurrenceType.OneTime,
+                    first_start=start,
+                    duration_seconds=600,
+                )
+            ],
             managers=["Admin"],
+            responsible=["Admin"],
         ),
         CalendarEntry(
             title="Alpha",
             description="",
             type=CalendarEntryType.Chore,
-            first_start=start,
-            duration_seconds=900,
+            recurrences=[
+                Recurrence(
+                    id=0,
+                    type=RecurrenceType.OneTime,
+                    first_start=start,
+                    duration_seconds=900,
+                )
+            ],
             managers=["Admin"],
+            responsible=["Admin"],
         ),
         CalendarEntry(
             title="Zeta",
             description="",
             type=CalendarEntryType.Chore,
-            first_start=start,
-            duration_seconds=360,
+            recurrences=[
+                Recurrence(
+                    id=0,
+                    type=RecurrenceType.OneTime,
+                    first_start=start,
+                    duration_seconds=360,
+                )
+            ],
             managers=["Admin"],
+            responsible=["Admin"],
         ),
     ]
     for entry in entries:
         app_module.calendar_store.create(entry)
 
     id_map = {e.title: e.id for e in app_module.calendar_store.list_entries()}
-    app_module.completion_store.create(id_map["Zeta"], -1, -1, "Admin")
+    app_module.completion_store.create(id_map["Zeta"], 0, 0, "Admin")
 
     response = client.get("/")
     text = response.text
@@ -85,25 +118,46 @@ def test_overdue_sorting(tmp_path, monkeypatch):
             title="Alpha",
             description="",
             type=CalendarEntryType.Chore,
-            first_start=fake_now - timedelta(minutes=20),
-            duration_seconds=300,
+            recurrences=[
+                Recurrence(
+                    id=0,
+                    type=RecurrenceType.OneTime,
+                    first_start=fake_now - timedelta(minutes=20),
+                    duration_seconds=300,
+                )
+            ],
             managers=["Admin"],
+            responsible=["Admin"],
         ),
         CalendarEntry(
             title="Beta",
             description="",
             type=CalendarEntryType.Chore,
-            first_start=fake_now - timedelta(minutes=10),
-            duration_seconds=300,
+            recurrences=[
+                Recurrence(
+                    id=0,
+                    type=RecurrenceType.OneTime,
+                    first_start=fake_now - timedelta(minutes=10),
+                    duration_seconds=300,
+                )
+            ],
             managers=["Admin"],
+            responsible=["Admin"],
         ),
         CalendarEntry(
             title="Gamma",
             description="",
             type=CalendarEntryType.Chore,
-            first_start=fake_now - timedelta(minutes=10),
-            duration_seconds=300,
+            recurrences=[
+                Recurrence(
+                    id=0,
+                    type=RecurrenceType.OneTime,
+                    first_start=fake_now - timedelta(minutes=10),
+                    duration_seconds=300,
+                )
+            ],
             managers=["Admin"],
+            responsible=["Admin"],
         ),
     ]
     for entry in entries:

--- a/tests/test_instance_duration_override.py
+++ b/tests/test_instance_duration_override.py
@@ -29,13 +29,17 @@ def test_instance_duration_override(tmp_path, monkeypatch):
     client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
 
     start = get_now() - timedelta(minutes=30)
+    rec = Recurrence(
+        id=0,
+        type=RecurrenceType.Weekly,
+        first_start=start,
+        duration_seconds=3600,
+    )
     entry = CalendarEntry(
         title="Task",
         description="",
         type=CalendarEntryType.Chore,
-        first_start=start,
-        duration_seconds=3600,
-        recurrences=[Recurrence(type=RecurrenceType.Weekly)],
+        recurrences=[rec],
         responsible=["Admin"],
         managers=["Admin"],
     )
@@ -45,8 +49,8 @@ def test_instance_duration_override(tmp_path, monkeypatch):
     resp = client.post(
         f"/calendar/{entry_id}/duration",
         data={
-            "recurrence_index": -1,
-            "instance_index": -1,
+            "recurrence_id": 0,
+            "instance_index": 0,
             "duration_days": "",
             "duration_hours": "2",
             "duration_minutes": "",
@@ -55,7 +59,7 @@ def test_instance_duration_override(tmp_path, monkeypatch):
     )
     assert resp.status_code == 303
 
-    page = client.get(f"/calendar/entry/{entry_id}/period/-1/-1")
+    page = client.get(f"/calendar/entry/{entry_id}/period/0/0")
     assert "Duration" in page.text
     assert "2:00" in page.text
 

--- a/tests/test_instance_notes.py
+++ b/tests/test_instance_notes.py
@@ -28,13 +28,17 @@ def test_instance_notes(tmp_path, monkeypatch):
     client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
 
     start = get_now() + timedelta(minutes=5)
+    rec = Recurrence(
+        id=0,
+        type=RecurrenceType.Weekly,
+        first_start=start,
+        duration_seconds=60,
+    )
     entry = CalendarEntry(
         title="Laundry",
         description="",
         type=CalendarEntryType.Chore,
-        first_start=start,
-        duration_seconds=60,
-        recurrences=[Recurrence(type=RecurrenceType.Weekly)],
+        recurrences=[rec],
         responsible=["Admin"],
         managers=["Admin"],
     )
@@ -43,12 +47,12 @@ def test_instance_notes(tmp_path, monkeypatch):
 
     resp = client.post(
         f"/calendar/{entry_id}/note",
-        data={"recurrence_index": -1, "instance_index": -1, "note": "<script>alert(1)</script>**Bold**"},
+        data={"recurrence_id": 0, "instance_index": 0, "note": "<script>alert(1)</script>**Bold**"},
         follow_redirects=False,
     )
     assert resp.status_code == 303
 
-    page = client.get(f"/calendar/entry/{entry_id}/period/-1/-1")
+    page = client.get(f"/calendar/entry/{entry_id}/period/0/0")
     assert "<script>alert(1)</script>" not in page.text
     assert "<strong>Bold</strong>" in page.text
 
@@ -57,7 +61,7 @@ def test_instance_notes(tmp_path, monkeypatch):
 
     resp = client.post(
         f"/calendar/{entry_id}/note/remove",
-        data={"recurrence_index": -1, "instance_index": -1},
+        data={"recurrence_id": 0, "instance_index": 0},
         follow_redirects=False,
     )
     assert resp.status_code == 303


### PR DESCRIPTION
## Summary
- adapt failing tests to the new recurrence-based CalendarEntry model
- drop obsolete first-instance-delegation delete test
- ensure split() keeps recurrences as models before storing specifics

## Testing
- `python scripts/test.py tests/test_calendar_entry_instances.py tests/test_calendar_list_active_past.py tests/test_calendar_list_disambiguation.py tests/test_chore_completions_page.py tests/test_delegate_instance.py tests/test_description_markdown.py tests/test_description_sanitized.py tests/test_entry_delete_restrictions.py tests/test_entry_managers.py tests/test_first_instance_delegation.py tests/test_hide_due_when_completed.py tests/test_index_sort_order.py tests/test_inline_edit.py tests/test_instance_duration_override.py tests/test_instance_notes.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb40c9cc88832c94d20715298a1d4d