### PR TITLE
Adjust tests for Recurrence-based calendar entries

### DIFF
--- a/tests/test_timeperiod_completed_by.py
+++ b/tests/test_timeperiod_completed_by.py
@@ -28,13 +28,17 @@ def test_completed_by_username_shown(tmp_path, monkeypatch):
     # login as Admin user
     client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
 
+    rec = Recurrence(
+        id=0,
+        type=RecurrenceType.Weekly,
+        first_start=datetime(2000, 1, 1, 8, 0, 0, tzinfo=ZoneInfo("UTC")),
+        duration_seconds=60,
+    )
     entry = CalendarEntry(
         title="Dishes",
         description="",
         type=CalendarEntryType.Chore,
-        first_start=datetime(2000, 1, 1, 8, 0, 0, tzinfo=ZoneInfo("UTC")),
-        duration_seconds=60,
-        recurrences=[Recurrence(type=RecurrenceType.Weekly)],
+        recurrences=[rec],
         managers=["Admin"],
     )
     app_module.calendar_store.create(entry)

--- a/tests/test_username_change_updates.py
+++ b/tests/test_username_change_updates.py
@@ -11,7 +11,6 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from choretracker.calendar import (
     CalendarEntry,
     CalendarEntryType,
-    InstanceSpecifics,
     Recurrence,
     RecurrenceType,
 )
@@ -25,28 +24,25 @@ def test_username_change_updates_references(tmp_path, monkeypatch):
     app_module = importlib.import_module("choretracker.app")
 
     app_module.user_store.create("Bob", "bob", None, set())
+    start = get_now() + timedelta(days=1)
+    rec = Recurrence(
+        id=0,
+        type=RecurrenceType.Weekly,
+        first_start=start,
+        duration_seconds=60,
+        responsible=["Bob"],
+    )
     entry = CalendarEntry(
         title="Test",
         description="",
         type=CalendarEntryType.Chore,
-        first_start=get_now() + timedelta(days=1),
-        duration_seconds=60,
+        recurrences=[rec],
         responsible=["Bob"],
         managers=["Bob"],
-        recurrences=[
-            Recurrence(
-                id=0,
-                type=RecurrenceType.Weekly,
-                responsible=["Bob"],
-            )
-        ],
-    )
-    entry.recurrences[0].instance_specifics[0] = InstanceSpecifics(
-        entry_id=0, recurrence_id=0, instance_index=0, responsible=["Bob"]
     )
     app_module.calendar_store.create(entry)
     entry_id = app_module.calendar_store.list_entries()[0].id
-    app_module.completion_store.create(entry_id, -1, -1, "Bob")
+    app_module.completion_store.create(entry_id, 0, 0, "Bob")
 
     client = TestClient(app_module.app)
     client.post(
@@ -69,7 +65,6 @@ def test_username_change_updates_references(tmp_path, monkeypatch):
     assert entry.managers == ["Bobby"]
     assert entry.responsible == ["Bobby"]
     assert entry.recurrences[0].responsible == ["Bobby"]
-    assert entry.recurrences[0].instance_specifics[0].responsible == ["Bobby"]
 
     comp = app_module.completion_store.list_for_entry(entry_id)[0]
     assert comp.completed_by == "Bobby"

--- a/tests/test_view_user_page.py
+++ b/tests/test_view_user_page.py
@@ -25,38 +25,53 @@ def test_view_user_page(tmp_path, monkeypatch):
     now = get_now()
 
     # entry where Bob responsible and completion
+    rec1 = Recurrence(
+        id=0,
+        type=RecurrenceType.OneTime,
+        first_start=now - timedelta(days=1),
+        duration_seconds=60,
+    )
     entry1 = CalendarEntry(
         title="Dishes",
         description="",
         type=CalendarEntryType.Chore,
-        first_start=now - timedelta(days=1),
-        duration_seconds=60,
+        recurrences=[rec1],
         responsible=["Bob"],
         managers=["Admin"],
     )
     app_module.calendar_store.create(entry1)
     entry1_id = app_module.calendar_store.list_entries()[0].id
-    app_module.completion_store.create(entry1_id, -1, -1, "Bob", completed_at=now)
+    app_module.completion_store.create(entry1_id, 0, 0, "Bob", completed_at=now)
 
     # entry where Bob responsible via recurrence
+    rec2 = Recurrence(
+        id=0,
+        type=RecurrenceType.Weekly,
+        first_start=now,
+        duration_seconds=60,
+        responsible=["Bob"],
+    )
     entry2 = CalendarEntry(
         title="Laundry",
         description="",
         type=CalendarEntryType.Chore,
-        first_start=now,
-        duration_seconds=60,
-        recurrences=[Recurrence(type=RecurrenceType.Weekly, responsible=["Bob"])],
+        recurrences=[rec2],
         managers=["Admin"],
     )
     app_module.calendar_store.create(entry2)
 
     # entry managed by Bob
+    rec3 = Recurrence(
+        id=0,
+        type=RecurrenceType.OneTime,
+        first_start=now,
+        duration_seconds=60,
+    )
     entry3 = CalendarEntry(
         title="Managed",
         description="",
         type=CalendarEntryType.Event,
-        first_start=now,
-        duration_seconds=60,
+        recurrences=[rec3],
         managers=["Bob"],
     )
     app_module.calendar_store.create(entry3)


### PR DESCRIPTION
## Summary
- adapt remaining tests to new Recurrence-first calendar data model
- remove outdated instance-specific rename assertion

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68bb4cb6dca4832c9278c60723353d49