### PR TITLE
Move start and duration to recurrence

### DIFF
--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -288,7 +288,14 @@ h1 .icon {
 
 .duration-inputs input {
     margin-right: 0.25rem;
+}
+
+.duration-inputs input[type="number"] {
     width: 4rem;
+}
+
+.duration-inputs input[type="datetime-local"] {
+    width: 16rem;
 }
 
 .responsible-selector {

--- a/choretracker/templates/calendar/form.html
+++ b/choretracker/templates/calendar/form.html
@@ -347,7 +347,14 @@ document.addEventListener('DOMContentLoaded', () => {
             li,
             validate: () => {
                 const ok = validateDuration();
-                if (ok && useEndTime) updateInputsFromEnd();
+                if (useEndTime) {
+                    if (ok) {
+                        updateInputsFromEnd();
+                    }
+                    [daysInput, hoursInput, minutesInput].forEach(inp => {
+                        inp.disabled = false;
+                    });
+                }
                 return { ok, focus: useEndTime ? endInput : daysInput };
             }
         };

--- a/choretracker/templates/calendar/form.html
+++ b/choretracker/templates/calendar/form.html
@@ -26,36 +26,10 @@
 
     <div class="field">
         <div class="label-row">
-            <label for="first_start">First start<span class="required">*</span></label>
-            <span class="help" data-help="Start time of the first instance">?</span>
-        </div>
-        <input type="datetime-local" id="first_start" name="first_start" required>
-    </div>
-
-    <div class="field">
-        <div class="label-row">
             <label for="none_before">None before</label>
             <span class="help" data-help="No instances start before this time">?</span>
         </div>
         <input type="datetime-local" id="none_before" name="none_before">
-    </div>
-
-    <div class="field">
-        <div class="label-row">
-            <span>Duration<span class="required">*</span></span>
-            <span class="help" data-help="Length of each instance">?</span>
-        </div>
-        <div class="duration-inputs">
-            <button type="button" id="toggle-duration-mode" class="icon-button">
-                <img id="duration-mode-icon" src="{{ url_for('static', path='endtime.svg') }}" alt="Use end time" class="icon">
-            </button>
-            <span id="duration-fields">
-                <input type="number" name="duration_days" placeholder="Days" min="0">
-                <input type="number" name="duration_hours" placeholder="Hours" min="0">
-                <input type="number" name="duration_minutes" placeholder="Minutes" min="0" max="59">
-            </span>
-            <input type="datetime-local" id="end_time" style="display:none">
-        </div>
     </div>
 
     <div class="field">
@@ -101,25 +75,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const recContainer = document.getElementById('recurrence-container');
     let recList = document.getElementById('recurrence-list');
     const addRecurrence = document.getElementById('add-recurrence');
-    const firstStart = document.getElementById('first_start');
-    if (firstStart && !firstStart.value) {
-        const now = new Date();
-        if (now.getMinutes() > 0 || now.getSeconds() > 0 || now.getMilliseconds() > 0) {
-            now.setHours(now.getHours() + 1);
-        }
-        now.setMinutes(0, 0, 0);
-        const local = new Date(now.getTime() - now.getTimezoneOffset() * 60000)
-            .toISOString()
-            .slice(0, 16);
-        firstStart.value = local;
-    }
-
     const trashUrl = "{{ url_for('static', path='trash.svg') }}";
     const plusUrl = "{{ url_for('static', path='plus.svg') }}";
     const xUrl = "{{ url_for('static', path='x.svg') }}";
     const profileUrlTemplate = "{{ url_for('profile_picture', username='__user__') }}";
     const allUsers = {{ all_users()|selectattr('username','ne','Viewer')|map(attribute='username')|list|tojson }};
     const recurrenceTypes = {{ RecurrenceType|map(attribute='value')|list|tojson }};
+    const durationUrl = "{{ url_for('static', path='duration.svg') }}";
+    const endTimeUrl = "{{ url_for('static', path='endtime.svg') }}";
+    const recEditors = [];
 
     function makeBtn(url, alt) {
         const b = document.createElement('button');
@@ -145,6 +109,146 @@ document.addEventListener('DOMContentLoaded', () => {
             opt.textContent = t;
             if (rec && rec.type === t) opt.selected = true;
             typeSelect.appendChild(opt);
+        });
+
+        const startInput = document.createElement('input');
+        startInput.type = 'datetime-local';
+        startInput.name = 'recurrence_first_start[]';
+        startInput.className = 'inline-input';
+        startInput.required = true;
+        if (rec && rec.first_start) {
+            startInput.value = rec.first_start.slice(0, 16);
+        } else {
+            const now = new Date();
+            if (now.getMinutes() > 0 || now.getSeconds() > 0 || now.getMilliseconds() > 0) {
+                now.setHours(now.getHours() + 1);
+            }
+            now.setMinutes(0, 0, 0);
+            const local = new Date(now.getTime() - now.getTimezoneOffset() * 60000)
+                .toISOString()
+                .slice(0, 16);
+            startInput.value = local;
+        }
+
+        const durationWrap = document.createElement('span');
+        durationWrap.className = 'duration-inputs';
+        const toggleBtn = makeBtn(endTimeUrl, 'Use end time');
+        const modeIcon = toggleBtn.querySelector('img');
+        const durationFields = document.createElement('span');
+        const daysInput = document.createElement('input');
+        daysInput.type = 'number';
+        daysInput.name = 'recurrence_duration_days[]';
+        daysInput.placeholder = 'Days';
+        daysInput.min = '0';
+        const hoursInput = document.createElement('input');
+        hoursInput.type = 'number';
+        hoursInput.name = 'recurrence_duration_hours[]';
+        hoursInput.placeholder = 'Hours';
+        hoursInput.min = '0';
+        const minutesInput = document.createElement('input');
+        minutesInput.type = 'number';
+        minutesInput.name = 'recurrence_duration_minutes[]';
+        minutesInput.placeholder = 'Minutes';
+        minutesInput.min = '0';
+        minutesInput.max = '59';
+        durationFields.appendChild(daysInput);
+        durationFields.appendChild(hoursInput);
+        durationFields.appendChild(minutesInput);
+        const endInput = document.createElement('input');
+        endInput.type = 'datetime-local';
+        endInput.style.display = 'none';
+        durationWrap.appendChild(toggleBtn);
+        durationWrap.appendChild(durationFields);
+        durationWrap.appendChild(endInput);
+
+        if (rec && rec.duration_seconds) {
+            const dur = rec.duration_seconds;
+            const d = Math.floor(dur / 86400);
+            const h = Math.floor((dur % 86400) / 3600);
+            const m = Math.floor((dur % 3600) / 60);
+            if (d) daysInput.value = d;
+            if (h) hoursInput.value = h;
+            if (m) minutesInput.value = m;
+        }
+
+        let useEndTime = false;
+        function computeDuration() {
+            if (useEndTime) {
+                const start = new Date(startInput.value);
+                const end = new Date(endInput.value);
+                return (end - start) / 1000;
+            } else {
+                const d = Number(daysInput.value) || 0;
+                const h = Number(hoursInput.value) || 0;
+                const m = Number(minutesInput.value) || 0;
+                return d * 86400 + h * 3600 + m * 60;
+            }
+        }
+        function validateDuration() {
+            const total = computeDuration();
+            const targets = useEndTime ? [endInput] : [daysInput, hoursInput, minutesInput];
+            targets.forEach(inp => {
+                if (total <= 0) {
+                    inp.setCustomValidity('Duration must be greater than 0');
+                } else {
+                    inp.setCustomValidity('');
+                }
+            });
+            return total > 0;
+        }
+        function updateEndFromInputs() {
+            const start = new Date(startInput.value);
+            const d = Number(daysInput.value) || 0;
+            const h = Number(hoursInput.value) || 0;
+            const m = Number(minutesInput.value) || 0;
+            const end = new Date(start.getTime() + (d * 86400 + h * 3600 + m * 60) * 1000);
+            const local = new Date(end.getTime() - end.getTimezoneOffset() * 60000)
+                .toISOString()
+                .slice(0, 16);
+            endInput.value = local;
+        }
+        function updateInputsFromEnd() {
+            const start = new Date(startInput.value);
+            const end = new Date(endInput.value);
+            let diff = Math.floor((end - start) / 1000);
+            const d = Math.floor(diff / 86400);
+            diff -= d * 86400;
+            const h = Math.floor(diff / 3600);
+            diff -= h * 3600;
+            const m = Math.floor(diff / 60);
+            daysInput.value = d || '';
+            hoursInput.value = h || '';
+            minutesInput.value = m || '';
+        }
+
+        toggleBtn.addEventListener('click', () => {
+            useEndTime = !useEndTime;
+            if (useEndTime) {
+                modeIcon.src = durationUrl;
+                modeIcon.alt = 'Use duration';
+                durationFields.style.display = 'none';
+                endInput.style.display = '';
+                updateEndFromInputs();
+            } else {
+                modeIcon.src = endTimeUrl;
+                modeIcon.alt = 'Use end time';
+                durationFields.style.display = '';
+                endInput.style.display = 'none';
+                updateInputsFromEnd();
+            }
+            validateDuration();
+        });
+
+        [daysInput, hoursInput, minutesInput].forEach(inp =>
+            inp.addEventListener('input', () => { if (!useEndTime) validateDuration(); })
+        );
+        endInput.addEventListener('input', () => { if (useEndTime) validateDuration(); });
+        startInput.addEventListener('input', () => {
+            if (useEndTime) {
+                validateDuration();
+            } else {
+                updateEndFromInputs();
+            }
         });
 
         const respContainer = document.createElement('span');
@@ -220,12 +324,26 @@ document.addEventListener('DOMContentLoaded', () => {
         const removeBtn = makeBtn(xUrl, 'Remove');
         removeBtn.addEventListener('click', () => {
             li.remove();
+            const idx = recEditors.findIndex(e => e.li === li);
+            if (idx >= 0) recEditors.splice(idx, 1);
             if (recList && recList.children.length === 0) {
                 recContainer.innerHTML = '';
             }
         });
 
+        const editor = {
+            li,
+            validate: () => {
+                const ok = validateDuration();
+                if (ok && useEndTime) updateInputsFromEnd();
+                return { ok, focus: useEndTime ? endInput : daysInput };
+            }
+        };
+        recEditors.push(editor);
+
         li.appendChild(typeSelect);
+        li.appendChild(startInput);
+        li.appendChild(durationWrap);
         li.appendChild(respContainer);
         li.appendChild(addWrap);
         li.appendChild(respHidden);
@@ -312,7 +430,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
         return { users };
     }
-
     const initialManagers = [];
     const initialResponsible = [];
 
@@ -320,14 +437,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const data = {{ entry_data | tojson }};
     document.getElementById('title').value = data.title;
     document.getElementById('description').value = data.description;
-    document.getElementById('first_start').value = data.first_start.slice(0,16);
-    const dur = data.duration_seconds;
-    const days = Math.floor(dur / 86400);
-    const hours = Math.floor((dur % 86400) / 3600);
-    const minutes = Math.floor((dur % 3600) / 60);
-    document.querySelector('input[name="duration_days"]').value = days || '';
-    document.querySelector('input[name="duration_hours"]').value = hours || '';
-    document.querySelector('input[name="duration_minutes"]').value = minutes || '';
     if (data.none_before) {
         document.getElementById('none_before').value = data.none_before.slice(0,16);
     }
@@ -355,82 +464,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const entryManagersSelector = setupUserSelector('entry-managers-container', 'managers', initialManagers);
 
     const form = document.getElementById('entry-form');
-    const durationInputs = document.querySelectorAll('#duration-fields input');
-    const endTimeInput = document.getElementById('end_time');
-    const toggleMode = document.getElementById('toggle-duration-mode');
-    const modeIcon = document.getElementById('duration-mode-icon');
-    let useEndTime = false;
-    function computeDuration() {
-        if (useEndTime) {
-            const start = new Date(document.getElementById('first_start').value);
-            const end = new Date(endTimeInput.value);
-            return (end - start) / 1000;
-        } else {
-            const days = Number(document.querySelector('input[name="duration_days"]').value) || 0;
-            const hours = Number(document.querySelector('input[name="duration_hours"]').value) || 0;
-            const minutes = Number(document.querySelector('input[name="duration_minutes"]').value) || 0;
-            return days * 86400 + hours * 3600 + minutes * 60;
-        }
-    }
-    function validateDuration() {
-        const total = computeDuration();
-        const targets = useEndTime ? [endTimeInput] : durationInputs;
-        targets.forEach(inp => {
-            if (total <= 0) {
-                inp.setCustomValidity('Duration must be greater than 0');
-            } else {
-                inp.setCustomValidity('');
-            }
-        });
-        return total > 0;
-    }
-    function updateEndFromInputs() {
-        const start = new Date(document.getElementById('first_start').value);
-        const days = Number(document.querySelector('input[name="duration_days"]').value) || 0;
-        const hours = Number(document.querySelector('input[name="duration_hours"]').value) || 0;
-        const minutes = Number(document.querySelector('input[name="duration_minutes"]').value) || 0;
-        const end = new Date(start.getTime() + (days * 86400 + hours * 3600 + minutes * 60) * 1000);
-        const local = new Date(end.getTime() - end.getTimezoneOffset() * 60000)
-            .toISOString()
-            .slice(0, 16);
-        endTimeInput.value = local;
-    }
-    function updateInputsFromEnd() {
-        const start = new Date(document.getElementById('first_start').value);
-        const end = new Date(endTimeInput.value);
-        const diff = end - start;
-        const days = Math.floor(diff / 86400000);
-        const hours = Math.floor((diff % 86400000) / 3600000);
-        const minutes = Math.floor((diff % 3600000) / 60000);
-        document.querySelector('input[name="duration_days"]').value = days || '';
-        document.querySelector('input[name="duration_hours"]').value = hours || '';
-        document.querySelector('input[name="duration_minutes"]').value = minutes || '';
-    }
-    toggleMode.addEventListener('click', () => {
-        useEndTime = !useEndTime;
-        if (useEndTime) {
-            modeIcon.src = "{{ url_for('static', path='duration.svg') }}";
-            document.getElementById('duration-fields').style.display = 'none';
-            endTimeInput.style.display = '';
-            updateEndFromInputs();
-        } else {
-            modeIcon.src = "{{ url_for('static', path='endtime.svg') }}";
-            document.getElementById('duration-fields').style.display = '';
-            endTimeInput.style.display = 'none';
-            updateInputsFromEnd();
-        }
-        validateDuration();
-    });
-    durationInputs.forEach(inp => inp.addEventListener('input', () => { if (!useEndTime) validateDuration(); }));
-    endTimeInput.addEventListener('input', () => { if (useEndTime) validateDuration(); });
     form.addEventListener('submit', function (e) {
-        if (!validateDuration()) {
-            e.preventDefault();
-            (useEndTime ? endTimeInput : durationInputs[0]).reportValidity();
-            return;
-        }
-        if (useEndTime) {
-            updateInputsFromEnd();
+        for (const editor of recEditors) {
+            const res = editor.validate();
+            if (!res.ok) {
+                e.preventDefault();
+                res.focus.reportValidity();
+                return;
+            }
         }
         if (entryManagersSelector.users.length === 0) {
             e.preventDefault();
@@ -447,4 +488,3 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 </script>
 {% endblock %}
-

--- a/choretracker/templates/calendar/form.html
+++ b/choretracker/templates/calendar/form.html
@@ -156,6 +156,7 @@ document.addEventListener('DOMContentLoaded', () => {
         durationFields.appendChild(minutesInput);
         const endInput = document.createElement('input');
         endInput.type = 'datetime-local';
+        endInput.className = 'inline-input';
         endInput.style.display = 'none';
         durationWrap.appendChild(toggleBtn);
         durationWrap.appendChild(durationFields);

--- a/choretracker/templates/calendar/form.html
+++ b/choretracker/templates/calendar/form.html
@@ -158,6 +158,7 @@ document.addEventListener('DOMContentLoaded', () => {
         endInput.type = 'datetime-local';
         endInput.className = 'inline-input';
         endInput.style.display = 'none';
+        endInput.disabled = true;
         durationWrap.appendChild(toggleBtn);
         durationWrap.appendChild(durationFields);
         durationWrap.appendChild(endInput);
@@ -228,13 +229,23 @@ document.addEventListener('DOMContentLoaded', () => {
                 modeIcon.src = durationUrl;
                 modeIcon.alt = 'Use duration';
                 durationFields.style.display = 'none';
+                [daysInput, hoursInput, minutesInput].forEach(inp => {
+                    inp.disabled = true;
+                    inp.setCustomValidity('');
+                });
                 endInput.style.display = '';
+                endInput.disabled = false;
                 updateEndFromInputs();
             } else {
                 modeIcon.src = endTimeUrl;
                 modeIcon.alt = 'Use end time';
                 durationFields.style.display = '';
+                [daysInput, hoursInput, minutesInput].forEach(inp => {
+                    inp.disabled = false;
+                });
                 endInput.style.display = 'none';
+                endInput.disabled = true;
+                endInput.setCustomValidity('');
                 updateInputsFromEnd();
             }
             validateDuration();


### PR DESCRIPTION
## Summary
- remove CalendarEntry-level first start and duration controls
- add per-recurrence start and duration selectors
- adjust server to accept start and duration per recurrence

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68bb537bf03c832cbba072cde5097465