### PR TITLE
Allow deletion of linked calendar entries

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -1433,7 +1433,7 @@ async def delete_calendar_entry(request: Request, entry_id: int):
     if not calendar_store.delete(entry_id):
         raise HTTPException(
             status_code=400,
-            detail="Entry has completions, delegations, or linked entries",
+            detail="Entry has completions or delegations",
         )
     return RedirectResponse(
         url=relative_url_for(request, "list_calendar_entries", entry_type=entry.type.value),


### PR DESCRIPTION
## Summary
- allow deleting calendar entries that are linked via `previous_entry` or `next_entry`
- adjust neighbors' links when an entry is removed
- clarify delete failure message
- add tests for link updates

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68bba3e63c48832c9f07ea81f85000ef