### PR TITLE
Hide completed chores after completion day

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -29,7 +29,7 @@ import base64
 import posixpath
 from jinja2 import pass_context
 
-from .time_utils import get_now, parse_datetime, ensure_tz
+from .time_utils import get_now, parse_datetime, ensure_tz, end_of_day
 from .users import (
     UserStore,
     init_db,
@@ -458,7 +458,10 @@ async def index(request: Request):
                     entry.id, period.recurrence_id, period.instance_index
                 )
                 if completion:
-                    if period.end <= now:
+                    visible_end = min(
+                        period.end, end_of_day(completion.completed_at)
+                    )
+                    if visible_end <= now:
                         continue
                     if period.start <= now:
                         current.append(

--- a/choretracker/time_utils.py
+++ b/choretracker/time_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime, tzinfo
+from datetime import datetime, tzinfo, timedelta
 from zoneinfo import ZoneInfo
 
 
@@ -40,4 +40,9 @@ def ensure_tz(dt: datetime | None) -> datetime | None:
     if dt is not None and dt.tzinfo is None:
         return dt.replace(tzinfo=_configured_tz())
     return dt
+
+
+def end_of_day(dt: datetime) -> datetime:
+    """Return the start of the next day in ``dt``'s timezone."""
+    return dt.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
 

--- a/tests/test_completed_chore_visibility.py
+++ b/tests/test_completed_chore_visibility.py
@@ -1,0 +1,68 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+)
+
+
+def test_completed_instance_hidden_after_day(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+    import choretracker.calendar as calendar_module
+
+    fake_now = datetime(2000, 1, 1, 10, 0, 0, tzinfo=ZoneInfo("UTC"))
+    monkeypatch.setattr(app_module, "get_now", lambda: fake_now)
+    monkeypatch.setattr(calendar_module, "get_now", lambda: fake_now)
+
+    client = TestClient(app_module.app)
+    client.post(
+        "/login",
+        data={"username": "Admin", "password": "admin"},
+        follow_redirects=False,
+    )
+
+    rec = Recurrence(
+        id=0,
+        type=RecurrenceType.OneTime,
+        first_start=fake_now - timedelta(hours=1),
+        duration_seconds=48 * 3600,
+    )
+    entry = CalendarEntry(
+        title="Long Chore",
+        description="",
+        type=CalendarEntryType.Chore,
+        recurrences=[rec],
+        managers=["Admin"],
+        responsible=["Admin"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    app_module.completion_store.create(entry_id, 0, 0, "Admin", completed_at=fake_now)
+
+    later_same_day = fake_now + timedelta(hours=1)
+    monkeypatch.setattr(app_module, "get_now", lambda: later_same_day)
+    monkeypatch.setattr(calendar_module, "get_now", lambda: later_same_day)
+    response = client.get("/")
+    assert "Long Chore" in response.text
+
+    next_day = fake_now + timedelta(days=1, hours=1)
+    monkeypatch.setattr(app_module, "get_now", lambda: next_day)
+    monkeypatch.setattr(calendar_module, "get_now", lambda: next_day)
+    response = client.get("/")
+    assert "Long Chore" not in response.text


### PR DESCRIPTION
## Summary
- Add `end_of_day` helper to compute the end of a day in the configured timezone
- Limit visibility of completed chore instances to the day they were completed
- Test that completed chores disappear from the index after the completion day

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68bba4b1f6a0832caf288a9e4ac5e72d