### PR TITLE
Link single-instance calendar entries to entry page

### DIFF
--- a/choretracker/calendar.py
+++ b/choretracker/calendar.py
@@ -525,6 +525,23 @@ def enumerate_time_periods(
             heappush(heap, (nxt.start, rid, gen, nxt))
 
 
+def has_single_instance(entry: CalendarEntry) -> bool:
+    """Return ``True`` if ``entry`` has only a single instance.
+
+    This checks the number of generated time periods for the entry and treats
+    skipped instances as still counting toward the total.  Only a single
+    ``next`` call is made after the first period to avoid generating the entire
+    sequence.
+    """
+
+    gen = enumerate_time_periods(entry, include_skipped=True)
+    first = next(gen, None)
+    if not first:
+        return True
+    second = next(gen, None)
+    return second is None
+
+
 def find_time_period(
     entry: CalendarEntry,
     recurrence_id: int,

--- a/choretracker/templates/index.html
+++ b/choretracker/templates/index.html
@@ -6,12 +6,16 @@
 {% if overdue %}
 <h2>Overdue</h2>
 <ul class="time-list">
-    {% for entry, period, responsible, has_note in overdue %}
+{% for entry, period, responsible, has_note, single in overdue %}
     <li>
         {% for user in responsible %}
         <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        <a href="{{ url_for('view_time_period', entry_id=entry.id, recurrence_id=period.recurrence_id, iindex=period.instance_index) }}">{{ entry.title }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
+        {% if single %}
+        <a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a>
+        {% else %}
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, recurrence_id=period.recurrence_id, iindex=period.instance_index) }}">{{ entry.title }}</a>
+        {% endif %}{% if has_note %}<span class="note-marker">*</span>{% endif %}
         <span class="time-suffix" data-kind="due-ago" data-end="{{ period.end.timestamp() }}"></span>
         {% if entry.type == CalendarEntryType.Chore %}
         <img src="{{ url_for('static', path='checkbox-empty.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rid="{{ period.recurrence_id }}" data-iindex="{{ period.instance_index }}" data-action="add" />
@@ -24,12 +28,16 @@
 {% if now_periods %}
 <h2>Now</h2>
 <ul class="time-list">
-    {% for entry, period, completion, responsible, has_note in now_periods %}
+{% for entry, period, completion, responsible, has_note, single in now_periods %}
     <li>
         {% for user in responsible %}
         <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        <a href="{{ url_for('view_time_period', entry_id=entry.id, recurrence_id=period.recurrence_id, iindex=period.instance_index) }}">{{ entry.title }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
+        {% if single %}
+        <a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a>
+        {% else %}
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, recurrence_id=period.recurrence_id, iindex=period.instance_index) }}">{{ entry.title }}</a>
+        {% endif %}{% if has_note %}<span class="note-marker">*</span>{% endif %}
         {% if entry.type == CalendarEntryType.Chore %}
         {% if completion %}
         <img src="{{ url_for('static', path='checkbox-checked.svg') }}" class="checkbox-icon" data-entry="{{ entry.id }}" data-rid="{{ period.recurrence_id }}" data-iindex="{{ period.instance_index }}" {% if completion.completed_by == request.session.get('user') or user_has(request.session.get('user'), 'chores.override_complete') %}data-action="remove"{% endif %} />
@@ -46,12 +54,16 @@
 {% if upcoming %}
 <h2>Upcoming</h2>
 <ul class="time-list">
-    {% for entry, period, responsible, has_note in upcoming %}
+{% for entry, period, responsible, has_note, single in upcoming %}
     <li>
         {% for user in responsible %}
         <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
         {% endfor %}
-        <a href="{{ url_for('view_time_period', entry_id=entry.id, recurrence_id=period.recurrence_id, iindex=period.instance_index) }}">{{ entry.title }}</a>{% if has_note %}<span class="note-marker">*</span>{% endif %}
+        {% if single %}
+        <a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a>
+        {% else %}
+        <a href="{{ url_for('view_time_period', entry_id=entry.id, recurrence_id=period.recurrence_id, iindex=period.instance_index) }}">{{ entry.title }}</a>
+        {% endif %}{% if has_note %}<span class="note-marker">*</span>{% endif %}
         <span class="time-suffix" data-kind="starts-in" data-start="{{ period.start.timestamp() }}"></span>
     </li>
     {% endfor %}

--- a/tests/test_single_instance_link.py
+++ b/tests/test_single_instance_link.py
@@ -1,0 +1,64 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+)
+
+
+def _setup_app(tmp_path, monkeypatch, fake_now):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+    monkeypatch.setattr(app_module, "get_now", lambda: fake_now)
+    import choretracker.calendar as calendar_module
+    monkeypatch.setattr(calendar_module, "get_now", lambda: fake_now)
+    client = TestClient(app_module.app)
+    client.post(
+        "/login",
+        data={"username": "Admin", "password": "admin"},
+        follow_redirects=False,
+    )
+    return app_module, client
+
+
+def test_single_instance_link_points_to_entry(tmp_path, monkeypatch):
+    fake_now = datetime(2000, 1, 1, tzinfo=ZoneInfo("UTC"))
+    app_module, client = _setup_app(tmp_path, monkeypatch, fake_now)
+
+    start = fake_now - timedelta(minutes=5)
+    entry = CalendarEntry(
+        title="Single",
+        description="",
+        type=CalendarEntryType.Event,
+        recurrences=[
+            Recurrence(
+                id=0,
+                type=RecurrenceType.OneTime,
+                first_start=start,
+                duration_seconds=600,
+            )
+        ],
+        managers=["Admin"],
+        responsible=["Admin"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    resp = client.get("/")
+    assert f"/calendar/entry/{entry_id}" in resp.text
+    assert f"/calendar/entry/{entry_id}/period/" not in resp.text
+


### PR DESCRIPTION
## Summary
- compute whether calendar entries have a single instance and pass this to the home page
- link single-instance entries on the home page to the calendar entry view instead of the instance view
- test single-instance link behavior

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68bbab1e6194832cb6ed33c35556d592