### PR TITLE
Add PIN keypad clear feature and reset on invalid entry

### DIFF
--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -454,6 +454,10 @@ textarea {
     grid-column: 3;
 }
 
+.keypad .clear {
+    grid-column: 1;
+}
+
 #pin-display {
     min-height: 1.5rem;
     margin-bottom: 0.5rem;

--- a/choretracker/templates/base.html
+++ b/choretracker/templates/base.html
@@ -130,7 +130,7 @@
                 <button class="key pin-key" data-value="7"><span class="num">7</span><span class="letters">PQRS</span></button>
                 <button class="key pin-key" data-value="8"><span class="num">8</span><span class="letters">TUV</span></button>
                 <button class="key pin-key" data-value="9"><span class="num">9</span><span class="letters">WXYZ</span></button>
-                <div></div>
+                <button class="key clear" id="pin-clear">Clear</button>
                 <button class="key pin-key" data-value="0"><span class="num">0</span><span class="letters"></span></button>
                 <button class="key enter" id="pin-enter">&#x2192;</button>
             </div>
@@ -204,11 +204,15 @@
         var currentNext = '';
         var pinValue = '';
 
+        function clearPinDigits() {
+            pinValue = '';
+            pinDisplay.textContent = '';
+        }
+
         function openPinModal(user, next) {
             currentUser = user;
             currentNext = next;
-            pinValue = '';
-            pinDisplay.textContent = '';
+            clearPinDigits();
             pinError.textContent = '';
             pinModal.style.display = 'flex';
         }
@@ -225,6 +229,10 @@
                 pinValue += this.dataset.value;
                 pinDisplay.textContent = pinValue.replace(/./g, '•');
             });
+        });
+        document.getElementById('pin-clear').addEventListener('click', function () {
+            clearPinDigits();
+            pinError.textContent = '';
         });
         document.getElementById('pin-enter').addEventListener('click', function () {
             performSwitch(currentUser, currentNext, pinValue);
@@ -260,10 +268,12 @@
                     } else {
                         resp.json().then(function (data) {
                             pinError.textContent = data.error || 'Invalid PIN';
+                            clearPinDigits();
                         });
                     }
                 }).catch(function () {
                     pinError.textContent = 'Network error';
+                    clearPinDigits();
                 });
             } else {
                 var xhr = new XMLHttpRequest();
@@ -281,10 +291,12 @@
                         window.location.href = data.redirect;
                     } else {
                         pinError.textContent = data.error || 'Invalid PIN';
+                        clearPinDigits();
                     }
                 };
                 xhr.onerror = function () {
                     pinError.textContent = 'Network error';
+                    clearPinDigits();
                 };
                 xhr.send('pin=' + encodeURIComponent(pin));
             }


### PR DESCRIPTION
## Summary
- Add "Clear" button to PIN keypad and position in lower left
- Reset PIN digits when incorrect or after network errors

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bbc38d7e20832c83174a587c306461