### PR TITLE
Add historical icon for past calendar items

### DIFF
--- a/choretracker/static/historical.svg
+++ b/choretracker/static/historical.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 3v6h6"/>
+  <path d="M3.05 13A9 9 0 1 0 12 3"/>
+  <path d="M12 7v5l4 2"/>
+</svg>

--- a/choretracker/static/historical.svg
+++ b/choretracker/static/historical.svg
@@ -1,5 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <path d="M3 3v6h6"/>
-  <path d="M3.05 13A9 9 0 1 0 12 3"/>
+  <!--<path d="M3.05 12A9 9 0 1 0 12 3"/>-->
+  <path d="M7 18A9 9 0 1 0 4 9"/>
   <path d="M12 7v5l4 2"/>
 </svg>

--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -48,6 +48,10 @@ h1 {
     vertical-align: middle;
 }
 
+.historical-icon {
+    margin-right: 0.25rem;
+}
+
 /* Larger icons for headings */
 h1 .icon {
     width: 1.5rem;

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -3,7 +3,12 @@
 {% block title %}{{ entry.title }} instance - Chore Tracker{% endblock %}
 
 {% block content %}
-<h1><a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a> instance</h1>
+<h1>
+    {% if historical %}
+    <img src="{{ url_for('static', path='historical.svg') }}" alt="Historical" class="icon historical-icon">
+    {% endif %}
+    <a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a> instance
+</h1>
 <div class="time-range">
     <span>{{ time_range_summary(period.start, period.end) }}</span>
     {% for user in responsible %}

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -4,6 +4,9 @@
 
 {% block content %}
 <h1 id="title-type">
+    {% if historical %}
+    <img src="{{ url_for('static', path='historical.svg') }}" alt="Historical" class="icon historical-icon">
+    {% endif %}
     <span id="title-text">{{ entry.title }}</span>
     <span id="type-text">{{ entry.type.value }}</span>
     {% if can_edit %}


### PR DESCRIPTION
## Summary
- show a historical clock icon for calendar entries and instances that have ended
- style the new icon and include SVG asset

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bbe6e2f180832c84b7fe2c475bf55f