### PR TITLE
Simplify navigation links on calendar entry page

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -1023,11 +1023,6 @@ async def view_calendar_entry(
     next_entry = (
         calendar_store.get(entry.next_entry) if entry.next_entry else None
     )
-    prev_start = prev_end = next_start = next_end = None
-    if prev_entry:
-        prev_start, prev_end = entry_time_bounds(prev_entry)
-    if next_entry:
-        next_start, next_end = entry_time_bounds(next_entry)
     current_user = request.session.get("user")
     now = get_now()
     historical = entry_end is not None and ensure_tz(entry_end) < now
@@ -1118,10 +1113,6 @@ async def view_calendar_entry(
             "entry_end_display": entry_end_display,
             "prev_entry": prev_entry,
             "next_entry": next_entry,
-            "prev_start": prev_start,
-            "prev_end": prev_end,
-            "next_start": next_start,
-            "next_end": next_end,
             "historical": historical,
         },
     )

--- a/choretracker/templates/calendar/view.html
+++ b/choretracker/templates/calendar/view.html
@@ -27,11 +27,12 @@
     🛑 <span id="none-after-display">{{ entry_end_display }}</span>
     {% if can_edit %}<button type="button" id="edit-none-after" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>{% endif %}
 </p>
-{% if prev_entry %}
-<p class="time-range">Previous: <a href="{{ url_for('view_calendar_entry', entry_id=prev_entry.id) }}">{{ time_range_summary(prev_start, prev_end) }}</a></p>
-{% endif %}
-{% if next_entry %}
-<p class="time-range">Next: <a href="{{ url_for('view_calendar_entry', entry_id=next_entry.id) }}">{{ time_range_summary(next_start, next_end) }}</a></p>
+{% if prev_entry or next_entry %}
+<p class="time-range">
+    {% if prev_entry %}<a href="{{ url_for('view_calendar_entry', entry_id=prev_entry.id) }}">←Previous</a>{% endif %}
+    {% if prev_entry and next_entry %} ― {% endif %}
+    {% if next_entry %}<a href="{{ url_for('view_calendar_entry', entry_id=next_entry.id) }}">Next→</a>{% endif %}
+</p>
 {% endif %}
 <div class="description" id="description-container">
     <div id="description-text">{{ entry.description|markdown|safe }}</div>


### PR DESCRIPTION
## Summary
- Consolidate previous/next navigation into a single line on calendar entry view
- Drop unused previous/next time range calculations in view handler

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bbed11f888832cbf5ddb9a60459a9a