### PR TITLE
Display instance time range like entry

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -1152,6 +1152,12 @@ async def view_time_period(
     )
     current_user = request.session.get("user")
     now = get_now()
+    period_start_display = format_range_start(period.start)
+    period_end_display = (
+        format_range_end(period.start, period.end)
+        if period.end is not None
+        else "Never"
+    )
     return templates.TemplateResponse(
         request,
         "calendar/timeperiod.html",
@@ -1169,6 +1175,8 @@ async def view_time_period(
             "duration_override": dur_override,
             "base_duration": base_duration,
             "historical": ensure_tz(period.end) < now,
+            "period_start_display": period_start_display,
+            "period_end_display": period_end_display,
         },
     )
 

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -9,8 +9,7 @@
     {% endif %}
     <a href="{{ url_for('view_calendar_entry', entry_id=entry.id) }}">{{ entry.title }}</a> instance
 </h1>
-<div class="time-range">
-    <span>{{ time_range_summary(period.start, period.end) }}</span>
+<p class="time-range">
     {% for user in responsible %}
     <img src="{{ url_for('profile_picture', username=user) }}" alt="{{ user }}" class="profile-icon" />
     {% endfor %}
@@ -32,7 +31,9 @@
         <span class="completed-by">by {{ completion.completed_by }}</span>
         {% endif %}
     {% endif %}
-</div>
+</p>
+<p class="time-range">🟢 {{ period_start_display }}</p>
+<p class="time-range">🛑 {{ period_end_display }}</p>
 <div class="description">{{ entry.description|markdown|safe }}</div>
 {% if can_edit %}
 <form method="post" action="{{ url_for(is_skipped and 'unskip_instance' or 'skip_instance', entry_id=entry.id) }}">


### PR DESCRIPTION
## Summary
- Show responsible users above instance times
- Format instance start and end like calendar entry view

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bbf0402698832c9c55877ae61cabe9