### PR TITLE
feat: allow overriding start time per instance

### DIFF
--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -32,7 +32,39 @@
         {% endif %}
     {% endif %}
 </p>
-<p class="time-range">🟢 {{ period_start_display }}</p>
+<p class="time-range" id="start-display-line">
+    🟢 <span id="start-display">{{ period_start_display }}</span>
+    {% if can_edit_start %}
+        <button type="button" id="edit-start" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
+        {% if start_override and can_remove_start %}
+        <form method="post" action="{{ url_for('remove_instance_start', entry_id=entry.id) }}" style="display:inline" class="delete-start-form">
+            <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
+            <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+            <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
+            <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
+        </form>
+        {% endif %}
+    {% endif %}
+</p>
+<div class="time-range" id="start-editor" style="display:none">
+    🟢
+    <form method="post" action="{{ url_for('set_instance_start', entry_id=entry.id) }}" style="display:inline" id="start-edit-form">
+        <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
+        <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+        <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
+        <input type="datetime-local" name="start_time" id="start-input" value="{{ period.start.strftime('%Y-%m-%dT%H:%M') }}" class="inline-input">
+        <button type="submit" class="icon-button"><img src="{{ url_for('static', path='disk.svg') }}" alt="Save" class="icon"></button>
+    </form>
+    {% if start_override and can_remove_start %}
+    <form method="post" action="{{ url_for('remove_instance_start', entry_id=entry.id) }}" style="display:inline" class="delete-start-form">
+        <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
+        <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+        <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
+        <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
+    </form>
+    {% endif %}
+    <button type="button" id="cancel-start" class="icon-button"><img src="{{ url_for('static', path='x.svg') }}" alt="Cancel" class="icon"></button>
+</div>
 <p class="time-range">🛑 {{ period_end_display }}</p>
 <div class="description">{{ entry.description|markdown|safe }}</div>
 {% if can_edit %}
@@ -190,6 +222,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const durationDisplay = document.getElementById('duration-display');
     const cancelDurationBtn = document.getElementById('cancel-duration');
 
+    const editStartBtn = document.getElementById('edit-start');
+    const startDisplayLine = document.getElementById('start-display-line');
+    const startEditor = document.getElementById('start-editor');
+    const cancelStartBtn = document.getElementById('cancel-start');
+
     function openNoteEditor() {
         if (noteEditor) noteEditor.style.display = 'block';
         if (noteDisplay) noteDisplay.style.display = 'none';
@@ -209,6 +246,37 @@ document.addEventListener('DOMContentLoaded', () => {
             addNoteBtn.style.display = '';
         }
     });
+
+    if (editStartBtn) {
+        editStartBtn.addEventListener('click', () => {
+            if (startDisplayLine) startDisplayLine.style.display = 'none';
+            if (startEditor) startEditor.style.display = '';
+        });
+    }
+    if (cancelStartBtn) {
+        cancelStartBtn.addEventListener('click', () => {
+            if (startEditor) startEditor.style.display = 'none';
+            if (startDisplayLine) startDisplayLine.style.display = '';
+        });
+    }
+
+    const startEditForm = document.getElementById('start-edit-form');
+    if (startEditForm) {
+        startEditForm.addEventListener('submit', e => {
+            e.preventDefault();
+            fetch(startEditForm.action, {
+                method: 'POST',
+                body: new FormData(startEditForm),
+                credentials: 'same-origin'
+            }).then(resp => {
+                if (resp.ok) {
+                    location.reload();
+                } else {
+                    resp.text().then(text => alert(text));
+                }
+            });
+        });
+    }
 
     if (durationEditor) {
     const toggleMode = document.getElementById('toggle-duration-mode');

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -32,7 +32,7 @@
         {% endif %}
     {% endif %}
 </p>
-<p class="time-range" id="start-display-line">
+<div class="time-range" id="start-display-line">
     🟢 <span id="start-display">{{ period_start_display }}</span>
     {% if can_edit_start %}
         {% if start_override and can_remove_start %}
@@ -45,7 +45,7 @@
         {% endif %}
         <button type="button" id="edit-start" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
     {% endif %}
-</p>
+</div>
 <div class="time-range" id="start-editor" style="display:none">
     🟢
     <form method="post" action="{{ url_for('set_instance_start', entry_id=entry.id) }}" style="display:inline" id="start-edit-form">

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -35,7 +35,6 @@
 <p class="time-range" id="start-display-line">
     🟢 <span id="start-display">{{ period_start_display }}</span>
     {% if can_edit_start %}
-        <button type="button" id="edit-start" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
         {% if start_override and can_remove_start %}
         <form method="post" action="{{ url_for('remove_instance_start', entry_id=entry.id) }}" style="display:inline" class="delete-start-form">
             <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
@@ -44,6 +43,7 @@
             <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
         </form>
         {% endif %}
+        <button type="button" id="edit-start" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
     {% endif %}
 </p>
 <div class="time-range" id="start-editor" style="display:none">
@@ -268,11 +268,23 @@ document.addEventListener('DOMContentLoaded', () => {
                 method: 'POST',
                 body: new FormData(startEditForm),
                 credentials: 'same-origin'
-            }).then(resp => {
+            }).then(async resp => {
                 if (resp.ok) {
                     location.reload();
                 } else {
-                    resp.text().then(text => alert(text));
+                    const ct = resp.headers.get('content-type') || '';
+                    let msg;
+                    if (ct.includes('application/json')) {
+                        try {
+                            const data = await resp.json();
+                            msg = data.detail || JSON.stringify(data);
+                        } catch {
+                            msg = await resp.text();
+                        }
+                    } else {
+                        msg = await resp.text();
+                    }
+                    alert(msg);
                 }
             });
         });

--- a/migrations/versions/d4a3b2c1e5f6_add_instance_start_override.py
+++ b/migrations/versions/d4a3b2c1e5f6_add_instance_start_override.py
@@ -1,0 +1,23 @@
+"""add instance start override
+
+Revision ID: d4a3b2c1e5f6
+Revises: ac12ef34bd56
+Create Date: 2025-09-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'd4a3b2c1e5f6'
+down_revision: Union[str, Sequence[str], None] = 'ac12ef34bd56'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('instancespecifics', sa.Column('start', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('instancespecifics', 'start')

--- a/tests/test_instance_start_override.py
+++ b/tests/test_instance_start_override.py
@@ -1,0 +1,180 @@
+import sys
+import importlib
+from pathlib import Path
+from datetime import timedelta
+
+from choretracker.time_utils import get_now
+from fastapi.testclient import TestClient
+
+# Ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from choretracker.calendar import (
+    CalendarEntry,
+    CalendarEntryType,
+    Recurrence,
+    RecurrenceType,
+    enumerate_time_periods,
+)
+
+
+def test_instance_start_override(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+    client = TestClient(app_module.app)
+
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    start = get_now() + timedelta(hours=1)
+    rec = Recurrence(
+        id=0,
+        type=RecurrenceType.OneTime,
+        first_start=start,
+        duration_seconds=3600,
+    )
+    entry = CalendarEntry(
+        title="Task",
+        description="",
+        type=CalendarEntryType.Event,
+        recurrences=[rec],
+        responsible=["Admin"],
+        managers=["Admin"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    new_start = (start + timedelta(hours=2)).replace(second=0, microsecond=0)
+    resp = client.post(
+        f"/calendar/{entry_id}/start",
+        data={
+            "recurrence_id": 0,
+            "instance_index": 0,
+            "start_time": new_start.strftime("%Y-%m-%dT%H:%M"),
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    entry = app_module.calendar_store.get(entry_id)
+    period = next(enumerate_time_periods(entry))
+    assert period.start == new_start
+
+    resp = client.post(
+        f"/calendar/{entry_id}/start/remove",
+        data={
+            "recurrence_id": 0,
+            "instance_index": 0,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    entry = app_module.calendar_store.get(entry_id)
+    period = next(enumerate_time_periods(entry))
+    assert period.start == start
+
+
+def test_start_override_order_enforced(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+    client = TestClient(app_module.app)
+
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    start = get_now() + timedelta(days=1)
+    rec = Recurrence(
+        id=0,
+        type=RecurrenceType.Weekly,
+        first_start=start,
+        duration_seconds=3600,
+    )
+    entry = CalendarEntry(
+        title="Task",
+        description="",
+        type=CalendarEntryType.Event,
+        recurrences=[rec],
+        responsible=["Admin"],
+        managers=["Admin"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    earlier = (start - timedelta(hours=1)).replace(second=0, microsecond=0)
+    resp = client.post(
+        f"/calendar/{entry_id}/start",
+        data={
+            "recurrence_id": 0,
+            "instance_index": 1,
+            "start_time": earlier.strftime("%Y-%m-%dT%H:%M"),
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    assert "previous instance's start" in resp.text
+
+    later = (start + timedelta(days=8)).replace(second=0, microsecond=0)
+    resp = client.post(
+        f"/calendar/{entry_id}/start",
+        data={
+            "recurrence_id": 0,
+            "instance_index": 0,
+            "start_time": later.strftime("%Y-%m-%dT%H:%M"),
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    assert "next instance's start" in resp.text
+
+
+def test_start_override_respects_other_recurrences(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("CHORETRACKER_DB", str(db_file))
+    if "choretracker.app" in sys.modules:
+        del sys.modules["choretracker.app"]
+    app_module = importlib.import_module("choretracker.app")
+    client = TestClient(app_module.app)
+
+    client.post("/login", data={"username": "Admin", "password": "admin"}, follow_redirects=False)
+
+    start = get_now() + timedelta(days=1)
+    rec0 = Recurrence(
+        id=0,
+        type=RecurrenceType.OneTime,
+        first_start=start,
+        duration_seconds=3600,
+    )
+    rec1 = Recurrence(
+        id=1,
+        type=RecurrenceType.OneTime,
+        first_start=start + timedelta(hours=2),
+        duration_seconds=3600,
+    )
+    entry = CalendarEntry(
+        title="Task",
+        description="",
+        type=CalendarEntryType.Event,
+        recurrences=[rec0, rec1],
+        responsible=["Admin"],
+        managers=["Admin"],
+    )
+    app_module.calendar_store.create(entry)
+    entry_id = app_module.calendar_store.list_entries()[0].id
+
+    new_start = (start - timedelta(hours=1)).replace(second=0, microsecond=0)
+    resp = client.post(
+        f"/calendar/{entry_id}/start",
+        data={
+            "recurrence_id": 1,
+            "instance_index": 0,
+            "start_time": new_start.strftime("%Y-%m-%dT%H:%M"),
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    assert "previous instance's start" in resp.text


### PR DESCRIPTION
## Summary
- allow per-instance start time overrides stored in InstanceSpecifics
- add UI and endpoints for editing, removing, and validating start overrides
- test start time override persistence and behavior
- ensure start override edits cannot reorder instances and show pop-up errors

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68bc7257d9d0832ca0fb11961ea7ece3