### PR TITLE
Refactor duration override editing

### DIFF
--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -296,12 +296,22 @@ textarea {
 }
 
 .duration-inputs {
-    display: flex;
-    flex-wrap: wrap;
+    display: inline-flex;
+    align-items: center;
 }
 
 .duration-inputs input {
     margin-right: 0.25rem;
+}
+
+.duration-inputs label {
+    display: inline-flex;
+    align-items: center;
+    margin-right: 0.25rem;
+}
+
+.duration-inputs label input {
+    margin-right: 0.1rem;
 }
 
 .duration-inputs input[type="number"] {

--- a/choretracker/static/styles.css
+++ b/choretracker/static/styles.css
@@ -300,10 +300,6 @@ textarea {
     flex-wrap: wrap;
 }
 
-.duration-display {
-    font-size: inherit;
-}
-
 .duration-inputs input {
     margin-right: 0.25rem;
 }

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -65,36 +65,23 @@
     {% endif %}
     <button type="button" id="cancel-start" class="icon-button"><img src="{{ url_for('static', path='x.svg') }}" alt="Cancel" class="icon"></button>
 </div>
-<p class="time-range">🛑 {{ period_end_display }}</p>
-<div class="description">{{ entry.description|markdown|safe }}</div>
-{% if can_edit %}
-<form method="post" action="{{ url_for(is_skipped and 'unskip_instance' or 'skip_instance', entry_id=entry.id) }}">
-    <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
-    <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
-    <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
-    <button type="submit" class="skip-button">{{ 'Do not skip this instance' if is_skipped else 'Skip this instance' }}</button>
-</form>
-{% endif %}
-{% if can_edit %}
-<div class="duration-section">
-    <h2>
-        Duration
+<div class="time-range" id="end-display-line">
+    🛑 <span id="end-display">{{ period_end_display }}</span>
+    {% if can_edit %}
         {% if duration_override %}
-            <button type="button" id="edit-duration" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
-            <form method="post" action="{{ url_for('remove_instance_duration', entry_id=entry.id) }}" style="display:inline" id="delete-duration-form">
-                <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
-                <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
-                <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
-                <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
-            </form>
-        {% else %}
-            <button type="button" id="add-duration" class="icon-button"><img src="{{ url_for('static', path='plus.svg') }}" alt="Add" class="icon"></button>
+        <form method="post" action="{{ url_for('remove_instance_duration', entry_id=entry.id) }}" style="display:inline" id="delete-duration-form">
+            <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
+            <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+            <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
+            <button type="submit" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
+        </form>
         {% endif %}
-    </h2>
-    {% if duration_override %}
-    <div id="duration-display" class="duration-display" data-duration-seconds="{{ duration_override.total_seconds()|int }}">{{ duration_override|format_duration }}</div>
+        <button type="button" id="edit-duration" class="icon-button"><img src="{{ url_for('static', path='pen.svg') }}" alt="Edit" class="icon"></button>
     {% endif %}
-    <form method="post" action="{{ url_for('set_instance_duration', entry_id=entry.id) }}" id="duration-editor" style="display:none">
+</div>
+<div class="time-range" id="end-editor" style="display:none">
+    🛑
+    <form method="post" action="{{ url_for('set_instance_duration', entry_id=entry.id) }}" id="duration-edit-form" style="display:inline">
         <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
         <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
         <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
@@ -109,12 +96,21 @@
             </span>
             <input type="datetime-local" name="end_time" id="end_time" class="inline-input" style="display:none">
         </div>
-        <div>
-            <button type="submit" class="icon-button"><img src="{{ url_for('static', path='disk.svg') }}" alt="Save" class="icon"></button>
-            <button type="button" id="cancel-duration" class="icon-button"><img src="{{ url_for('static', path='x.svg') }}" alt="Cancel" class="icon"></button>
-        </div>
+        {% if duration_override %}
+        <button type="submit" formaction="{{ url_for('remove_instance_duration', entry_id=entry.id) }}" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
+        {% endif %}
+        <button type="submit" class="icon-button"><img src="{{ url_for('static', path='disk.svg') }}" alt="Save" class="icon"></button>
     </form>
+    <button type="button" id="cancel-duration" class="icon-button"><img src="{{ url_for('static', path='x.svg') }}" alt="Cancel" class="icon"></button>
 </div>
+<div class="description">{{ entry.description|markdown|safe }}</div>
+{% if can_edit %}
+<form method="post" action="{{ url_for(is_skipped and 'unskip_instance' or 'skip_instance', entry_id=entry.id) }}">
+    <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
+    <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
+    <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
+    <button type="submit" class="skip-button">{{ 'Do not skip this instance' if is_skipped else 'Skip this instance' }}</button>
+</form>
 {% endif %}
 {% if can_edit or note %}
 <div class="additional-notes-section">
@@ -214,12 +210,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const cancelNoteBtn = document.getElementById('cancel-note');
 
     const durationExists = {{ 'true' if duration_override else 'false' }};
+    const currentDurationSeconds = {{ duration_override.total_seconds()|int if duration_override else 0 }};
     const defaultDurationSeconds = {{ base_duration.total_seconds()|int if base_duration else 0 }};
-    const addDurationBtn = document.getElementById('add-duration');
     const editDurationBtn = document.getElementById('edit-duration');
-    const deleteDurationForm = document.getElementById('delete-duration-form');
-    const durationEditor = document.getElementById('duration-editor');
-    const durationDisplay = document.getElementById('duration-display');
+    const endDisplayLine = document.getElementById('end-display-line');
+    const endEditor = document.getElementById('end-editor');
+    const durationEditForm = document.getElementById('duration-edit-form');
     const cancelDurationBtn = document.getElementById('cancel-duration');
 
     const editStartBtn = document.getElementById('edit-start');
@@ -290,14 +286,14 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    if (durationEditor) {
+    if (durationEditForm) {
     const toggleMode = document.getElementById('toggle-duration-mode');
     const modeIcon = document.getElementById('duration-mode-icon');
     const durationFields = document.getElementById('duration-fields');
     const endTimeInput = document.getElementById('end_time');
-    const dayInput = durationEditor.querySelector('input[name="duration_days"]');
-    const hourInput = durationEditor.querySelector('input[name="duration_hours"]');
-    const minuteInput = durationEditor.querySelector('input[name="duration_minutes"]');
+    const dayInput = durationEditForm.querySelector('input[name="duration_days"]');
+    const hourInput = durationEditForm.querySelector('input[name="duration_hours"]');
+    const minuteInput = durationEditForm.querySelector('input[name="duration_minutes"]');
     let useEndTime = false;
     const periodStart = new Date("{{ period.start.strftime('%Y-%m-%dT%H:%M') }}");
 
@@ -337,11 +333,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     function openDurationEditor(initial) {
-        if (durationEditor) durationEditor.style.display = 'block';
-        if (durationDisplay) durationDisplay.style.display = 'none';
-        if (addDurationBtn) addDurationBtn.style.display = 'none';
-        if (editDurationBtn) editDurationBtn.style.display = 'none';
-        if (deleteDurationForm) deleteDurationForm.style.display = 'none';
+        if (endDisplayLine) endDisplayLine.style.display = 'none';
+        if (endEditor) endEditor.style.display = 'block';
         const days = Math.floor(initial / 86400);
         const hours = Math.floor((initial % 86400) / 3600);
         const minutes = Math.floor((initial % 3600) / 60);
@@ -354,22 +347,15 @@ document.addEventListener('DOMContentLoaded', () => {
         durationFields.style.display = '';
         endTimeInput.style.display = 'none';
     }
-    if (addDurationBtn) addDurationBtn.addEventListener('click', () => openDurationEditor(defaultDurationSeconds));
     if (editDurationBtn) editDurationBtn.addEventListener('click', () => {
-        const secs = parseInt(durationDisplay.dataset.durationSeconds || '0');
+        const secs = durationExists ? currentDurationSeconds : defaultDurationSeconds;
         openDurationEditor(secs);
     });
     if (cancelDurationBtn) cancelDurationBtn.addEventListener('click', () => {
-        if (durationEditor) durationEditor.style.display = 'none';
-        if (durationDisplay) durationDisplay.style.display = '';
-        if (durationExists) {
-            if (editDurationBtn) editDurationBtn.style.display = '';
-            if (deleteDurationForm) deleteDurationForm.style.display = 'inline';
-        } else if (addDurationBtn) {
-            addDurationBtn.style.display = '';
-        }
+        if (endEditor) endEditor.style.display = 'none';
+        if (endDisplayLine) endDisplayLine.style.display = '';
     });
-    durationEditor.addEventListener('submit', e => {
+    durationEditForm.addEventListener('submit', e => {
         if (useEndTime) {
             const diff = new Date(endTimeInput.value) - periodStart;
             if (diff <= 0) {

--- a/choretracker/templates/calendar/timeperiod.html
+++ b/choretracker/templates/calendar/timeperiod.html
@@ -85,23 +85,23 @@
         <input type="hidden" name="recurrence_id" value="{{ period.recurrence_id }}" />
         <input type="hidden" name="instance_index" value="{{ period.instance_index }}" />
         <input type="hidden" name="csrf_token" value="{{ request.session['csrf_token'] }}" />
-        <div class="duration-inputs">
+        <span class="duration-inputs">
             <button type="button" id="toggle-duration-mode" class="icon-button">
                 <img id="duration-mode-icon" src="{{ url_for('static', path='endtime.svg') }}" alt="Use end time" class="icon">
             </button>
             <span id="duration-fields">
-                <input type="number" class="inline-input" name="duration_days" placeholder="Days" min="0">
-                <input type="number" class="inline-input" name="duration_hours" placeholder="Hours" min="0">
-                <input type="number" class="inline-input" name="duration_minutes" placeholder="Minutes" min="0" max="59">
+                <label><input type="number" class="inline-input" name="duration_days" placeholder="Days" min="0">d</label>
+                <label><input type="number" class="inline-input" name="duration_hours" placeholder="Hours" min="0">h</label>
+                <label><input type="number" class="inline-input" name="duration_minutes" placeholder="Minutes" min="0" max="59">m</label>
             </span>
             <input type="datetime-local" name="end_time" id="end_time" class="inline-input" style="display:none">
-        </div>
+        </span>
         {% if duration_override %}
         <button type="submit" formaction="{{ url_for('remove_instance_duration', entry_id=entry.id) }}" class="icon-button"><img src="{{ url_for('static', path='trash.svg') }}" alt="Delete" class="icon"></button>
         {% endif %}
         <button type="submit" class="icon-button"><img src="{{ url_for('static', path='disk.svg') }}" alt="Save" class="icon"></button>
+        <button type="button" id="cancel-duration" class="icon-button"><img src="{{ url_for('static', path='x.svg') }}" alt="Cancel" class="icon"></button>
     </form>
-    <button type="button" id="cancel-duration" class="icon-button"><img src="{{ url_for('static', path='x.svg') }}" alt="Cancel" class="icon"></button>
 </div>
 <div class="description">{{ entry.description|markdown|safe }}</div>
 {% if can_edit %}

--- a/tests/test_instance_duration_override.py
+++ b/tests/test_instance_duration_override.py
@@ -60,11 +60,13 @@ def test_instance_duration_override(tmp_path, monkeypatch):
     assert resp.status_code == 303
 
     page = client.get(f"/calendar/entry/{entry_id}/period/0/0")
-    assert "Duration" in page.text
-    assert "2:00" in page.text
+    assert 'id="edit-duration"' in page.text
+    assert 'id="delete-duration-form"' in page.text
 
     entry = app_module.calendar_store.get(entry_id)
     period = next(enumerate_time_periods(entry))
+    end_display = app_module.format_range_end(period.start, period.end)
+    assert end_display in page.text
     assert (period.end - period.start) == timedelta(hours=2)
 
     home = client.get("/")


### PR DESCRIPTION
## Summary
- Replace separate duration section with inline duration editing on the end time line
- Support editing via pen icon and optional trash icon, including toggle between duration fields and end time
- Clean up unused duration display style and update tests

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bc8ca4a93c832cb2ac24beab1149ed