### PR TITLE
Remove empty instance specifics

### DIFF
--- a/choretracker/app.py
+++ b/choretracker/app.py
@@ -1724,16 +1724,10 @@ async def remove_delegation(request: Request, entry_id: int):
         if not isinstance(spec, InstanceSpecifics):
             spec = InstanceSpecifics.model_validate(spec)
         spec.responsible = None
-        if (
-            not spec.skip
-            and spec.duration_seconds is None
-            and spec.responsible is None
-            and spec.note is None
-            and spec.start is None
-        ):
-            del specs[iindex]
-        else:
+        if spec.has_overrides():
             specs[iindex] = spec
+        else:
+            del specs[iindex]
     rec.instance_specifics = specs
     calendar_store.update(entry_id, entry)
     referer = request.headers.get(
@@ -1900,16 +1894,10 @@ async def remove_instance_start(request: Request, entry_id: int):
                 detail="Cannot move instance entirely into the past",
             )
         spec.start = None
-        if (
-            not spec.skip
-            and spec.duration_seconds is None
-            and spec.responsible is None
-            and spec.note is None
-            and spec.start is None
-        ):
-            del specs[iindex]
-        else:
+        if spec.has_overrides():
             specs[iindex] = spec
+        else:
+            del specs[iindex]
     rec.instance_specifics = specs
     calendar_store.update(entry_id, entry)
     referer = request.headers.get(
@@ -2014,16 +2002,10 @@ async def remove_instance_duration(request: Request, entry_id: int):
         if not isinstance(spec, InstanceSpecifics):
             spec = InstanceSpecifics.model_validate(spec)
         spec.duration_seconds = None
-        if (
-            not spec.skip
-            and spec.duration_seconds is None
-            and spec.responsible is None
-            and spec.note is None
-            and spec.start is None
-        ):
-            del specs[iindex]
-        else:
+        if spec.has_overrides():
             specs[iindex] = spec
+        else:
+            del specs[iindex]
     rec.instance_specifics = specs
     calendar_store.update(entry_id, entry)
     referer = request.headers.get(
@@ -2117,16 +2099,10 @@ async def remove_instance_note(request: Request, entry_id: int):
         if not isinstance(spec, InstanceSpecifics):
             spec = InstanceSpecifics.model_validate(spec)
         spec.note = None
-        if (
-            not spec.skip
-            and spec.duration_seconds is None
-            and spec.responsible is None
-            and spec.note is None
-            and spec.start is None
-        ):
-            del specs[iindex]
-        else:
+        if spec.has_overrides():
             specs[iindex] = spec
+        else:
+            del specs[iindex]
     rec.instance_specifics = specs
     calendar_store.update(entry_id, entry)
     referer = request.headers.get(
@@ -2203,13 +2179,8 @@ async def unskip_instance(request: Request, entry_id: int):
     if spec:
         if not isinstance(spec, InstanceSpecifics):
             spec = InstanceSpecifics.model_validate(spec)
-        if (
-            spec.responsible
-            or spec.note
-            or spec.duration_seconds is not None
-            or spec.start is not None
-        ):
-            spec.skip = False
+        spec.skip = False
+        if spec.has_overrides():
             specs[iindex] = spec
         else:
             specs.pop(iindex)

--- a/tests/test_delegate_instance.py
+++ b/tests/test_delegate_instance.py
@@ -66,7 +66,21 @@ def test_delegate_instance(tmp_path, monkeypatch):
     assert "trash.svg" in page.text
     assert "pen.svg" in page.text
 
-    # Additional delegation scenarios tested elsewhere; removal not yet supported in new model
+    resp = client.post(
+        f"/calendar/{entry_id}/delegation/remove",
+        data={"recurrence_id": 0, "instance_index": 0},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    entry = app_module.calendar_store.get(entry_id)
+    rec = entry.recurrences[0]
+    if not isinstance(rec, Recurrence):
+        rec = Recurrence.model_validate(rec)
+    assert 0 not in rec.instance_specifics
+    assert responsible_for(entry, 0, 0) == ["Admin"]
+
+    # Additional delegation scenarios tested elsewhere
 
 
 def test_delegate_instance_requires_user(tmp_path, monkeypatch):

--- a/tests/test_responsible_overrides.py
+++ b/tests/test_responsible_overrides.py
@@ -42,4 +42,4 @@ def test_responsible_hierarchy():
     entry.recurrences[0].instance_specifics[3] = InstanceSpecifics(
         entry_id=0, recurrence_id=0, instance_index=3, responsible=[]
     )
-    assert responsible_for(entry, 0, 3) == []
+    assert responsible_for(entry, 0, 3) == ["carol"]


### PR DESCRIPTION
## Summary
- ignore instance-specific records with no effective overrides
- drop empty responsible overrides when delegations are removed
- test delegation removal and updated responsible hierarchy

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68bca1aa6fcc832c9678cc1389813172